### PR TITLE
feat(processing): add create_processing_model tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ uv run --no-sync pytest tests/ -v
 | `execute_processing` | Execute Processing | — | Run QGIS Processing algorithm (60s, async+progress+logging) |
 | `list_processing_algorithms` | List Processing Algorithms | readOnly | Search algorithms by keyword/provider |
 | `get_algorithm_help` | Get Algorithm Help | readOnly | Algorithm parameters, outputs, description |
-| `create_processing_model` | Create Processing Model | — | Build a `.model3` workflow from a structured spec (inputs, steps, outputs); supports `@input` / `$step.OUTPUT` / `=expression` references |
+| `create_processing_model` | Create Processing Model | — | Build a `.model3` workflow from a structured spec (inputs, steps, outputs); always saved into the QGIS user models folder and registered (numeric suffix on name collision); supports `@input` / `$step.OUTPUT` / `=expression` references |
 | `render_map` | Render Map | idempotent | Render canvas to inline image (60s, async+progress+logging) |
 | `execute_code` | Execute Code | destructive | Run arbitrary PyQGIS code (60s, async+progress+logging) |
 | `batch_commands` | Batch Commands | — | Multiple commands in one round-trip |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ uv run --no-sync pytest tests/ -v
 | `QGIS_MCP_LOG_LEVEL` | `INFO` | File log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `QGIS_MCP_TOOL_MODE` | `granular` | Tool registration mode: `granular` (51 tools) or `compound` (~19 grouped tools) |
 
-## MCP Tools (51 total)
+## MCP Tools (52 total)
 
 | Tool | Title | Annotations | Description |
 |---|---|---|---|
@@ -92,6 +92,7 @@ uv run --no-sync pytest tests/ -v
 | `execute_processing` | Execute Processing | — | Run QGIS Processing algorithm (60s, async+progress+logging) |
 | `list_processing_algorithms` | List Processing Algorithms | readOnly | Search algorithms by keyword/provider |
 | `get_algorithm_help` | Get Algorithm Help | readOnly | Algorithm parameters, outputs, description |
+| `create_processing_model` | Create Processing Model | — | Build a `.model3` workflow from a structured spec (inputs, steps, outputs); supports `@input` / `$step.OUTPUT` / `=expression` references |
 | `render_map` | Render Map | idempotent | Render canvas to inline image (60s, async+progress+logging) |
 | `execute_code` | Execute Code | destructive | Run arbitrary PyQGIS code (60s, async+progress+logging) |
 | `batch_commands` | Batch Commands | — | Multiple commands in one round-trip |
@@ -132,6 +133,7 @@ uv run --no-sync pytest tests/ -v
 | `analyze_layer` | Inspect schema, sample data, compute statistics |
 | `spatial_analysis` | Spatial operation between two layers with CRS check |
 | `style_map` | Create thematic map with symbology (now uses set_layer_style tool) |
+| `create_processing_model` | Translate a natural-language workflow description into a saved `.model3` Processing Model |
 
 ## MCP Protocol Features
 

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -1429,14 +1429,12 @@ class QgisMCPServer(QObject):
         steps,
         inputs=None,
         outputs=None,
-        path=None,
         description="",
         group="Models",
-        register=False,
-        overwrite=False,
         **kwargs,
     ):
-        """Build a Processing Model from a structured spec and save it to a .model3 file.
+        """Build a Processing Model from a structured spec, save it into the
+        QGIS user models folder under a unique name, and register it.
 
         Reference syntax in step parameter values:
           "@input_name"        – model input parameter
@@ -1451,9 +1449,39 @@ class QgisMCPServer(QObject):
 
         registry = QgsApplication.processingRegistry()
 
+        # ---- Resolve models folder & pick a unique file name up front ----
+        provider = registry.providerById("model")
+        models_dir = None
+        if provider is not None and hasattr(provider, "modelsFolder"):
+            try:
+                models_dir = provider.modelsFolder()
+            except Exception:
+                models_dir = None
+        if models_dir is None:
+            models_dir = os.path.join(
+                QgsApplication.qgisSettingsDirPath(), "processing", "models"
+            )
+        os.makedirs(models_dir, exist_ok=True)
+
+        final_name = name
+        target_path = os.path.join(models_dir, f"{final_name}.model3")
+        if os.path.exists(target_path):
+            for suffix in range(2, 1001):
+                candidate = f"{name}_{suffix}"
+                candidate_path = os.path.join(models_dir, f"{candidate}.model3")
+                if not os.path.exists(candidate_path):
+                    final_name = candidate
+                    target_path = candidate_path
+                    break
+            else:
+                raise Exception(
+                    f"Could not find a unique name for '{name}' in {models_dir} "
+                    "(tried up to _1000)"
+                )
+
         # ---- Build model skeleton ----
         model = QgsProcessingModelAlgorithm()
-        model.setName(name)
+        model.setName(final_name)
         if group:
             model.setGroup(group)
         if description:
@@ -1568,48 +1596,13 @@ class QgisMCPServer(QObject):
                 mo.setDescription("Result")
                 last_child.setModelOutputs({"Result": mo})
 
-        # ---- Resolve target path ----
-        models_dir = None
-        provider = registry.providerById("model")
-        if provider is not None and hasattr(provider, "modelsFolder"):
-            try:
-                models_dir = provider.modelsFolder()
-            except Exception:
-                models_dir = None
-        if models_dir is None:
-            models_dir = os.path.join(
-                QgsApplication.qgisSettingsDirPath(), "processing", "models"
-            )
-
-        if path:
-            target_path = os.path.expanduser(path)
-            if not target_path.endswith(".model3"):
-                target_path += ".model3"
-        elif register:
-            os.makedirs(models_dir, exist_ok=True)
-            target_path = os.path.join(models_dir, f"{name}.model3")
-        else:
-            raise Exception("Either 'path' must be provided or 'register' must be True")
-
-        if os.path.exists(target_path) and not overwrite:
-            raise Exception(
-                f"File already exists: {target_path}. Pass overwrite=True to replace it."
-            )
-
-        os.makedirs(os.path.dirname(target_path) or ".", exist_ok=True)
+        # ---- Write the .model3 file directly into the models folder ----
         if not model.toFile(target_path):
             raise Exception(f"Failed to write model to {target_path}")
 
-        # ---- Optional registration in the user's models folder ----
+        # ---- Register with the model provider so it shows up in the toolbox ----
         registered = False
-        registered_path = None
-        if register and provider is not None:
-            os.makedirs(models_dir, exist_ok=True)
-            registered_path = os.path.join(models_dir, f"{name}.model3")
-            if os.path.abspath(registered_path) != os.path.abspath(target_path):
-                import shutil
-
-                shutil.copyfile(target_path, registered_path)
+        if provider is not None:
             try:
                 provider.refreshAlgorithms()
                 registered = True
@@ -1619,14 +1612,14 @@ class QgisMCPServer(QObject):
                 )
 
         QgsMessageLog.logMessage(
-            f"Processing model '{name}' saved to {target_path}", self.LOG_TAG, MSG_INFO
+            f"Processing model '{final_name}' saved to {target_path}", self.LOG_TAG, MSG_INFO
         )
         return {
             "ok": True,
-            "name": name,
+            "name": final_name,
+            "requested_name": name,
             "path": target_path,
             "registered": registered,
-            "registered_path": registered_path if registered else None,
             "input_count": len(defined_inputs),
             "step_count": len(defined_steps),
             "output_count": sum(len(v) for v in outputs_by_step.values()) or (1 if defined_steps else 0),

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -33,6 +33,25 @@ from qgis.core import (
     QgsMapSettings,
     QgsMessageLog,
     QgsPointXY,
+    QgsProcessingModelAlgorithm,
+    QgsProcessingModelChildAlgorithm,
+    QgsProcessingModelChildParameterSource,
+    QgsProcessingModelOutput,
+    QgsProcessingModelParameter,
+    QgsProcessingParameterBoolean,
+    QgsProcessingParameterCrs,
+    QgsProcessingParameterDistance,
+    QgsProcessingParameterEnum,
+    QgsProcessingParameterExtent,
+    QgsProcessingParameterFeatureSource,
+    QgsProcessingParameterField,
+    QgsProcessingParameterFile,
+    QgsProcessingParameterMultipleLayers,
+    QgsProcessingParameterNumber,
+    QgsProcessingParameterPoint,
+    QgsProcessingParameterRasterLayer,
+    QgsProcessingParameterString,
+    QgsProcessingParameterVectorLayer,
     QgsProject,
     QgsRasterLayer,
     QgsRectangle,
@@ -44,7 +63,16 @@ from qgis.core import (
     QgsVectorLayer,
     QgsWkbTypes,
 )
-from qgis.PyQt.QtCore import QBuffer, QByteArray, QObject, QSize, QTimer, QUrl, QVariant
+from qgis.PyQt.QtCore import (
+    QBuffer,
+    QByteArray,
+    QObject,
+    QPointF,
+    QSize,
+    QTimer,
+    QUrl,
+    QVariant,
+)
 from qgis.PyQt.QtGui import QColor, QDesktopServices, QIcon
 from qgis.PyQt.QtWidgets import (
     QAction,
@@ -284,6 +312,7 @@ class QgisMCPServer(QObject):
                 "create_memory_layer": self.create_memory_layer,
                 "list_processing_algorithms": self.list_processing_algorithms,
                 "get_algorithm_help": self.get_algorithm_help,
+                "create_processing_model": self.create_processing_model,
                 "find_layer": self.find_layer,
                 "list_layouts": self.list_layouts,
                 "export_layout": self.export_layout,
@@ -1215,6 +1244,397 @@ class QgisMCPServer(QObject):
             "provider": alg.provider().id(),
             "parameters": params,
             "outputs": outputs,
+        }
+
+    # ------------------------------------------------------------------
+    # Processing Model construction
+    # ------------------------------------------------------------------
+
+    def _resolve_algorithm_id(self, hint, registry):
+        """Resolve an algorithm hint to a fully-qualified id (e.g. 'native:buffer').
+
+        Direct lookup against ``QgsApplication.processingRegistry()``: the LLM
+        passes a keyword like ``"buffer"`` or a full id, and this matches it
+        against algorithm ids, display names and tags. Falls back with a
+        candidate list when the hint is ambiguous, so the caller can refine.
+        """
+        if not isinstance(hint, str) or not hint.strip():
+            raise Exception("Algorithm hint must be a non-empty string")
+        hint_clean = hint.strip()
+
+        # 1. Exact id match (incl. fully qualified 'native:buffer').
+        alg = registry.algorithmById(hint_clean)
+        if alg is not None:
+            return alg.id()
+
+        hint_lower = hint_clean.lower()
+        exact_name = []   # display name == hint
+        suffix_id = []    # id suffix == hint (after ':')
+        contains = []     # display name or id suffix contains hint
+        for alg in registry.algorithms():
+            alg_id = alg.id()
+            id_suffix = alg_id.split(":", 1)[-1].lower()
+            disp = alg.displayName().lower()
+            if disp == hint_lower:
+                exact_name.append(alg)
+            elif id_suffix == hint_lower:
+                suffix_id.append(alg)
+            elif hint_lower in disp or hint_lower in id_suffix:
+                contains.append(alg)
+
+        def _pick(group):
+            if len(group) == 1:
+                return group[0].id()
+            natives = [a for a in group if a.provider().id() == "native"]
+            if len(natives) == 1:
+                return natives[0].id()
+            return None
+
+        for group in (exact_name, suffix_id, contains):
+            picked = _pick(group)
+            if picked:
+                return picked
+
+        all_candidates = exact_name + suffix_id + contains
+        if not all_candidates:
+            raise Exception(
+                f"No Processing algorithm matches '{hint_clean}'. "
+                "Pass a keyword found in the algorithm name or its full id (e.g. 'native:buffer')."
+            )
+        # Show up to 8 candidates so the LLM can disambiguate next call.
+        sample = ", ".join(
+            f"{a.id()} ({a.displayName()})"
+            for a in sorted(all_candidates, key=lambda a: (a.provider().id() != "native", len(a.id())))[:8]
+        )
+        raise Exception(
+            f"Algorithm hint '{hint_clean}' is ambiguous. Candidates: {sample}. "
+            "Use the full id."
+        )
+
+    def _build_param_source(self, value, defined_inputs, defined_steps):
+        """Convert a JSON-friendly value into a QgsProcessingModelChildParameterSource.
+
+        String prefixes:
+          @name          -> reference to model input parameter
+          $step.OUTPUT   -> reference to a previous step's output
+          =expression    -> evaluated QGIS expression
+        Lists are converted element-wise; everything else becomes a static value.
+        """
+        Src = QgsProcessingModelChildParameterSource
+
+        if isinstance(value, list):
+            return [self._build_param_source(v, defined_inputs, defined_steps)[0] for v in value]
+
+        if isinstance(value, str):
+            if value.startswith("@"):
+                ref = value[1:]
+                if ref not in defined_inputs:
+                    raise Exception(
+                        f"Parameter reference '{value}' points to undefined model input '{ref}'"
+                    )
+                return [Src.fromModelParameter(ref)]
+            if value.startswith("$"):
+                rest = value[1:]
+                if "." not in rest:
+                    raise Exception(
+                        f"Step output reference '{value}' must be in '$step_id.OUTPUT_NAME' form"
+                    )
+                child_id, output_name = rest.split(".", 1)
+                if child_id not in defined_steps:
+                    raise Exception(
+                        f"Step output reference '{value}' points to undefined step '{child_id}'"
+                    )
+                return [Src.fromChildOutput(child_id, output_name)]
+            if value.startswith("="):
+                return [Src.fromExpression(value[1:])]
+
+        return [Src.fromStaticValue(value)]
+
+    def _make_input_definition(self, spec):
+        """Build a QgsProcessingParameterDefinition from a JSON spec dict."""
+        type_name = (spec.get("type") or "string").lower()
+        name = spec["name"]
+        description = spec.get("description", name)
+        default = spec.get("default", None)
+        optional = bool(spec.get("optional", False))
+
+        if type_name in ("vector", "vector_layer"):
+            param = QgsProcessingParameterVectorLayer(name, description, defaultValue=default)
+        elif type_name in ("feature_source", "source"):
+            param = QgsProcessingParameterFeatureSource(name, description, defaultValue=default)
+        elif type_name in ("raster", "raster_layer"):
+            param = QgsProcessingParameterRasterLayer(name, description, defaultValue=default)
+        elif type_name == "field":
+            parent = spec.get("parent_layer")
+            if not parent:
+                raise Exception(f"Input '{name}' of type 'field' requires 'parent_layer'")
+            param = QgsProcessingParameterField(
+                name, description, parentLayerParameterName=parent, defaultValue=default
+            )
+        elif type_name in ("number", "int", "integer", "float", "double"):
+            param = QgsProcessingParameterNumber(name, description, defaultValue=default)
+            if type_name in ("int", "integer"):
+                with contextlib.suppress(AttributeError):
+                    param.setDataType(QgsProcessingParameterNumber.Integer)
+        elif type_name == "distance":
+            param = QgsProcessingParameterDistance(name, description, defaultValue=default)
+            parent = spec.get("parent_layer")
+            if parent:
+                param.setParentParameterName(parent)
+        elif type_name == "string":
+            param = QgsProcessingParameterString(name, description, defaultValue=default)
+        elif type_name in ("boolean", "bool"):
+            param = QgsProcessingParameterBoolean(
+                name, description, defaultValue=bool(default) if default is not None else False
+            )
+        elif type_name == "extent":
+            param = QgsProcessingParameterExtent(name, description, defaultValue=default)
+        elif type_name == "crs":
+            param = QgsProcessingParameterCrs(
+                name, description, defaultValue=default or "EPSG:4326"
+            )
+        elif type_name == "point":
+            param = QgsProcessingParameterPoint(name, description, defaultValue=default)
+        elif type_name == "file":
+            param = QgsProcessingParameterFile(name, description, defaultValue=default)
+        elif type_name == "folder":
+            param = QgsProcessingParameterFile(name, description, defaultValue=default)
+            try:
+                param.setBehavior(QgsProcessingParameterFile.Folder)
+            except AttributeError:
+                try:
+                    param.setBehavior(Qgis.ProcessingFileParameterBehavior.Folder)
+                except AttributeError:
+                    pass
+        elif type_name == "enum":
+            options = spec.get("options") or []
+            param = QgsProcessingParameterEnum(
+                name, description, options=options, defaultValue=default
+            )
+        elif type_name in ("multiple_layers", "layers"):
+            param = QgsProcessingParameterMultipleLayers(name, description, defaultValue=default)
+        else:
+            raise Exception(f"Unsupported input type '{type_name}' for input '{name}'")
+
+        if optional:
+            try:
+                param.setFlags(param.flags() | PROCESSING_OPTIONAL)
+            except Exception:
+                pass
+        return param
+
+    def create_processing_model(
+        self,
+        name,
+        steps,
+        inputs=None,
+        outputs=None,
+        path=None,
+        description="",
+        group="Models",
+        register=False,
+        overwrite=False,
+        **kwargs,
+    ):
+        """Build a Processing Model from a structured spec and save it to a .model3 file.
+
+        Reference syntax in step parameter values:
+          "@input_name"        – model input parameter
+          "$step_id.OUTPUT"    – output of a previous step
+          "=expression"        – QGIS expression
+          anything else        – static literal (numbers, bools, strings, lists, ...)
+        """
+        if not name or not isinstance(name, str):
+            raise Exception("Model 'name' is required")
+        if not isinstance(steps, list) or not steps:
+            raise Exception("'steps' must be a non-empty list")
+
+        registry = QgsApplication.processingRegistry()
+
+        # ---- Build model skeleton ----
+        model = QgsProcessingModelAlgorithm()
+        model.setName(name)
+        if group:
+            model.setGroup(group)
+        if description:
+            try:
+                model.setHelpContent({"ALG_DESC": description})
+            except Exception:
+                pass
+
+        # ---- Inputs ----
+        defined_inputs = set()
+        for idx, spec in enumerate(inputs or []):
+            if not isinstance(spec, dict) or "name" not in spec:
+                raise Exception(f"Input #{idx} must be a dict with at least 'name'")
+            param_def = self._make_input_definition(spec)
+            mp = QgsProcessingModelParameter(spec["name"])
+            mp.setPosition(QPointF(50.0, 50.0 + idx * 100.0))
+            model.addModelParameter(param_def, mp)
+            defined_inputs.add(spec["name"])
+
+        # ---- Steps ----
+        # Validate shape & resolve algorithm hints up front so we never write
+        # a half-built file. Each step entry is normalized to a fully-qualified
+        # algorithm id stored under '_resolved_algorithm'.
+        defined_steps: list[str] = []
+        resolved: list[tuple[dict, str]] = []  # (step_spec, resolved_alg_id)
+        seen_ids: set[str] = set()
+        for idx, step in enumerate(steps):
+            if not isinstance(step, dict):
+                raise Exception(f"Step #{idx} must be a dict")
+            for required in ("id", "algorithm"):
+                if required not in step:
+                    raise Exception(f"Step #{idx} missing required key '{required}'")
+            if step["id"] in seen_ids:
+                raise Exception(f"Duplicate step id '{step['id']}'")
+            seen_ids.add(step["id"])
+            try:
+                alg_id = self._resolve_algorithm_id(step["algorithm"], registry)
+            except Exception as e:
+                raise Exception(f"Step '{step['id']}': {e}") from e
+            alg = registry.algorithmById(alg_id)
+            valid_params = {p.name() for p in alg.parameterDefinitions()}
+            for pname in (step.get("parameters") or {}):
+                if pname not in valid_params:
+                    raise Exception(
+                        f"Step '{step['id']}' (algorithm '{alg_id}'): unknown parameter "
+                        f"'{pname}'. Valid parameters: {sorted(valid_params)}"
+                    )
+            resolved.append((step, alg_id))
+
+        # Outputs may be marked on a per-step basis; collect them by step id
+        outputs_by_step: dict[str, dict[str, dict]] = {}
+        step_id_to_alg: dict[str, str] = {step["id"]: alg_id for step, alg_id in resolved}
+        for out_idx, out_spec in enumerate(outputs or []):
+            if not isinstance(out_spec, dict):
+                raise Exception(f"Output #{out_idx} must be a dict")
+            for required in ("name", "from_step", "from_output"):
+                if required not in out_spec:
+                    raise Exception(f"Output #{out_idx} missing required key '{required}'")
+            from_step = out_spec["from_step"]
+            if from_step not in step_id_to_alg:
+                raise Exception(
+                    f"Output '{out_spec['name']}': from_step '{from_step}' is not a defined step"
+                )
+            from_alg = registry.algorithmById(step_id_to_alg[from_step])
+            valid_outputs = {o.name() for o in from_alg.outputDefinitions()}
+            if out_spec["from_output"] not in valid_outputs:
+                raise Exception(
+                    f"Output '{out_spec['name']}': '{out_spec['from_output']}' is not an output "
+                    f"of step '{from_step}' (algorithm '{step_id_to_alg[from_step]}'). "
+                    f"Valid outputs: {sorted(valid_outputs)}"
+                )
+            outputs_by_step.setdefault(from_step, {})[out_spec["name"]] = out_spec
+
+        for step_idx, (step, alg_id) in enumerate(resolved):
+            child = QgsProcessingModelChildAlgorithm(alg_id)
+            child.setChildId(step["id"])
+            child.setDescription(step.get("description") or registry.algorithmById(alg_id).displayName())
+            child.setPosition(QPointF(300.0 + step_idx * 250.0, 50.0))
+
+            for pname, pvalue in (step.get("parameters") or {}).items():
+                # Build sources, validating refs against already-defined inputs/steps.
+                sources = self._build_param_source(pvalue, defined_inputs, set(defined_steps))
+                child.addParameterSources(pname, sources)
+
+            # Final outputs declared for this step
+            step_outputs = outputs_by_step.get(step["id"], {})
+            if step_outputs:
+                model_outputs = {}
+                for out_name, out_spec in step_outputs.items():
+                    mo = QgsProcessingModelOutput(out_name)
+                    mo.setChildId(step["id"])
+                    mo.setChildOutputName(out_spec["from_output"])
+                    mo.setDescription(out_spec.get("description") or out_name)
+                    model_outputs[out_name] = mo
+                child.setModelOutputs(model_outputs)
+
+            model.addChildAlgorithm(child)
+            defined_steps.append(step["id"])
+
+        # If the user did not declare any outputs, expose the last step's OUTPUT
+        # under a default name so the model produces something the user can save.
+        if not outputs and defined_steps:
+            last_step_id = defined_steps[-1]
+            last_child = model.childAlgorithm(last_step_id)
+            last_alg = registry.algorithmById(last_child.algorithmId())
+            output_names = [o.name() for o in last_alg.outputDefinitions()] if last_alg else []
+            preferred = "OUTPUT" if "OUTPUT" in output_names else (output_names[0] if output_names else None)
+            if preferred:
+                mo = QgsProcessingModelOutput("Result")
+                mo.setChildId(last_step_id)
+                mo.setChildOutputName(preferred)
+                mo.setDescription("Result")
+                last_child.setModelOutputs({"Result": mo})
+
+        # ---- Resolve target path ----
+        models_dir = None
+        provider = registry.providerById("model")
+        if provider is not None and hasattr(provider, "modelsFolder"):
+            try:
+                models_dir = provider.modelsFolder()
+            except Exception:
+                models_dir = None
+        if models_dir is None:
+            models_dir = os.path.join(
+                QgsApplication.qgisSettingsDirPath(), "processing", "models"
+            )
+
+        if path:
+            target_path = os.path.expanduser(path)
+            if not target_path.endswith(".model3"):
+                target_path += ".model3"
+        elif register:
+            os.makedirs(models_dir, exist_ok=True)
+            target_path = os.path.join(models_dir, f"{name}.model3")
+        else:
+            raise Exception("Either 'path' must be provided or 'register' must be True")
+
+        if os.path.exists(target_path) and not overwrite:
+            raise Exception(
+                f"File already exists: {target_path}. Pass overwrite=True to replace it."
+            )
+
+        os.makedirs(os.path.dirname(target_path) or ".", exist_ok=True)
+        if not model.toFile(target_path):
+            raise Exception(f"Failed to write model to {target_path}")
+
+        # ---- Optional registration in the user's models folder ----
+        registered = False
+        registered_path = None
+        if register and provider is not None:
+            os.makedirs(models_dir, exist_ok=True)
+            registered_path = os.path.join(models_dir, f"{name}.model3")
+            if os.path.abspath(registered_path) != os.path.abspath(target_path):
+                import shutil
+
+                shutil.copyfile(target_path, registered_path)
+            try:
+                provider.refreshAlgorithms()
+                registered = True
+            except Exception as e:
+                QgsMessageLog.logMessage(
+                    f"Model saved but provider refresh failed: {e}", self.LOG_TAG, MSG_WARNING
+                )
+
+        QgsMessageLog.logMessage(
+            f"Processing model '{name}' saved to {target_path}", self.LOG_TAG, MSG_INFO
+        )
+        return {
+            "ok": True,
+            "name": name,
+            "path": target_path,
+            "registered": registered,
+            "registered_path": registered_path if registered else None,
+            "input_count": len(defined_inputs),
+            "step_count": len(defined_steps),
+            "output_count": sum(len(v) for v in outputs_by_step.values()) or (1 if defined_steps else 0),
+            # Echo the resolved algorithm ids so the caller can confirm fuzzy matches.
+            "resolved_steps": [
+                {"id": step["id"], "algorithm": alg_id, "hint": step["algorithm"]}
+                for step, alg_id in resolved
+            ],
         }
 
     def find_layer(self, name_pattern, **kwargs):

--- a/src/qgis_mcp/compound_tools.py
+++ b/src/qgis_mcp/compound_tools.py
@@ -444,9 +444,10 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
             "- list_algorithms: search (str, optional), provider (str, optional)\n"
             "- get_help: algorithm_id (str)\n"
             "- create_model: name (str), steps (list[dict]), inputs (list[dict], optional), "
-            "outputs (list[dict], optional), path (str, optional), description (str, optional), "
-            "group (str, optional), register (bool, optional), overwrite (bool, optional). "
-            "Step parameter values support '@input', '$step.OUTPUT', '=expression', or static literals."
+            "outputs (list[dict], optional), description (str, optional), group (str, optional). "
+            "Step parameter values support '@input', '$step.OUTPUT', '=expression', or static literals. "
+            "The model is always saved into the QGIS user models folder and registered; a numeric "
+            "suffix is appended to the name on collision."
         ),
     )
     async def processing(ctx: Context, action: str, **kwargs) -> dict[str, Any]:
@@ -478,10 +479,8 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
                 "steps": kwargs["steps"],
                 "description": kwargs.get("description", ""),
                 "group": kwargs.get("group", "Models"),
-                "register": kwargs.get("register", False),
-                "overwrite": kwargs.get("overwrite", False),
             }
-            for key in ("inputs", "outputs", "path"):
+            for key in ("inputs", "outputs"):
                 if key in kwargs and kwargs[key] is not None:
                     params[key] = kwargs[key]
             return await _send("create_processing_model", params, timeout=TIMEOUT_LONG)

--- a/src/qgis_mcp/compound_tools.py
+++ b/src/qgis_mcp/compound_tools.py
@@ -439,10 +439,14 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
         title="Processing",
         description=(
             "QGIS Processing framework.\n"
-            "Actions: execute, list_algorithms, get_help\n"
+            "Actions: execute, list_algorithms, get_help, create_model\n"
             "- execute: algorithm (str), parameters (dict)\n"
             "- list_algorithms: search (str, optional), provider (str, optional)\n"
-            "- get_help: algorithm_id (str)"
+            "- get_help: algorithm_id (str)\n"
+            "- create_model: name (str), steps (list[dict]), inputs (list[dict], optional), "
+            "outputs (list[dict], optional), path (str, optional), description (str, optional), "
+            "group (str, optional), register (bool, optional), overwrite (bool, optional). "
+            "Step parameter values support '@input', '$step.OUTPUT', '=expression', or static literals."
         ),
     )
     async def processing(ctx: Context, action: str, **kwargs) -> dict[str, Any]:
@@ -465,6 +469,22 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
             return await _send("list_processing_algorithms", params)
         elif action == "get_help":
             return await _send("get_algorithm_help", {"algorithm_id": kwargs["algorithm_id"]})
+        elif action == "create_model":
+            await ctx.info(
+                f"Building Processing model: {kwargs['name']} ({len(kwargs['steps'])} step(s))"
+            )
+            params = {
+                "name": kwargs["name"],
+                "steps": kwargs["steps"],
+                "description": kwargs.get("description", ""),
+                "group": kwargs.get("group", "Models"),
+                "register": kwargs.get("register", False),
+                "overwrite": kwargs.get("overwrite", False),
+            }
+            for key in ("inputs", "outputs", "path"):
+                if key in kwargs and kwargs[key] is not None:
+                    params[key] = kwargs[key]
+            return await _send("create_processing_model", params, timeout=TIMEOUT_LONG)
         else:
             raise ValueError(f"Unknown processing action: {action}")
 

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -726,7 +726,8 @@ async def get_algorithm_help(ctx: Context, algorithm_id: str) -> dict[str, Any]:
 @mcp.tool(
     title="Create Processing Model",
     description=(
-        "Build and save a QGIS Processing Model (.model3 workflow) from a structured spec. "
+        "Build a QGIS Processing Model (.model3 workflow) from a structured spec, save it into "
+        "the QGIS user models folder, and register it in the Processing Toolbox. "
         "This is the only call needed: algorithm discovery and parameter validation happen "
         "inside the plugin against the live QGIS Processing registry — DO NOT call "
         "list_processing_algorithms or get_algorithm_help first. Pass a keyword like 'buffer' "
@@ -745,9 +746,11 @@ async def get_algorithm_help(ctx: Context, algorithm_id: str) -> dict[str, Any]:
         "    anything else      – a static literal (number, bool, string, list, ...)\n"
         "  outputs: [{name, from_step, from_output, description?}] – final outputs the model exposes. "
         "If omitted, the OUTPUT of the last step is exposed automatically as 'Result'.\n\n"
-        "Save modes: pass 'path' to save anywhere, or set register=True to also copy the model into the "
-        "user's Processing models folder so it appears in the Processing Toolbox after refresh.\n\n"
-        "The response echoes 'resolved_steps' so the caller can verify which algorithm each hint mapped to."
+        "The model is always saved into the QGIS user profile's Processing models folder. If "
+        "'<name>.model3' already exists, a unique suffix is appended ('<name>_2.model3', "
+        "'<name>_3.model3', ...). The actual filename used is returned as 'name' alongside the "
+        "originally requested name as 'requested_name'. The response also echoes 'resolved_steps' "
+        "so the caller can verify which algorithm each hint mapped to."
     ),
     structured_output=True,
 )
@@ -757,11 +760,8 @@ async def create_processing_model(
     steps: list[dict],
     inputs: list[dict] | None = None,
     outputs: list[dict] | None = None,
-    path: str | None = None,
     description: str = "",
     group: str = "Models",
-    register: bool = False,
-    overwrite: bool = False,
 ) -> dict[str, Any]:
     await ctx.info(f"Building Processing model: {name} ({len(steps)} step(s))")
     params: dict[str, Any] = {
@@ -769,15 +769,11 @@ async def create_processing_model(
         "steps": steps,
         "description": description,
         "group": group,
-        "register": register,
-        "overwrite": overwrite,
     }
     if inputs is not None:
         params["inputs"] = inputs
     if outputs is not None:
         params["outputs"] = outputs
-    if path is not None:
-        params["path"] = path
     return await _send("create_processing_model", params, timeout=TIMEOUT_LONG)
 
 
@@ -1525,14 +1521,7 @@ def spatial_analysis_prompt(
     name="create_processing_model",
     description="Translate a natural-language workflow description into a saved QGIS Processing Model",
 )
-def create_processing_model_prompt(
-    description: str, path: str | None = None
-) -> list[UserMessage]:
-    target = (
-        f"Save the model to: {path}."
-        if path
-        else "Ask the user where to save the model, or pass register=True to drop it into the user's Processing models folder."
-    )
+def create_processing_model_prompt(description: str) -> list[UserMessage]:
     return [
         UserMessage(
             content=(
@@ -1545,9 +1534,11 @@ def create_processing_model_prompt(
                 "if a keyword is ambiguous the tool returns the candidate list so you can retry "
                 "with a more specific hint. Reference model inputs as '@name', earlier step "
                 "outputs as '$step_id.OUTPUT', and QGIS expressions as '=expr'. "
-                f"{target} "
-                "After the call, summarize the resolved_steps it returned so the user can verify "
-                "the algorithm choices."
+                "The model is always saved into the QGIS user models folder and registered in the "
+                "Processing Toolbox; if the requested name is taken the tool appends a numeric "
+                "suffix and returns the actual filename used. "
+                "After the call, summarize the resolved_steps it returned and tell the user the "
+                "final model name so they can find it in the toolbox."
             )
         )
     ]

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -271,7 +271,7 @@ mcp = FastMCP(
 
 
 # ===========================================================================
-# MCP TOOLS (51 total)
+# MCP TOOLS (52 total)
 # ===========================================================================
 
 # --- Connectivity & Info ---
@@ -721,6 +721,64 @@ async def list_processing_algorithms(
 )
 async def get_algorithm_help(ctx: Context, algorithm_id: str) -> dict[str, Any]:
     return await _send("get_algorithm_help", {"algorithm_id": algorithm_id})
+
+
+@mcp.tool(
+    title="Create Processing Model",
+    description=(
+        "Build and save a QGIS Processing Model (.model3 workflow) from a structured spec. "
+        "This is the only call needed: algorithm discovery and parameter validation happen "
+        "inside the plugin against the live QGIS Processing registry — DO NOT call "
+        "list_processing_algorithms or get_algorithm_help first. Pass a keyword like 'buffer' "
+        "or 'centroids' (or a full id like 'native:buffer') and the handler resolves it; on an "
+        "ambiguous hint it returns the candidate list so you can refine and retry. Unknown "
+        "parameter or output names are reported with the valid set for the algorithm.\n\n"
+        "Spec shape:\n"
+        "  inputs: [{name, type, description?, default?, optional?, parent_layer? (for 'field'/'distance'), "
+        "options? (for 'enum')}]. Types: vector, feature_source, raster, field, number, integer, distance, "
+        "string, boolean, extent, crs, point, file, folder, enum, multiple_layers.\n"
+        "  steps: [{id, algorithm, description?, parameters: {ALG_PARAM: value, ...}}]. "
+        "'algorithm' may be a fuzzy keyword or a full id. Step parameter values use:\n"
+        "    '@input_name'      – the value of a model input\n"
+        "    '$step_id.OUTPUT'  – an output of an earlier step\n"
+        "    '=expression'      – a QGIS expression evaluated at run time\n"
+        "    anything else      – a static literal (number, bool, string, list, ...)\n"
+        "  outputs: [{name, from_step, from_output, description?}] – final outputs the model exposes. "
+        "If omitted, the OUTPUT of the last step is exposed automatically as 'Result'.\n\n"
+        "Save modes: pass 'path' to save anywhere, or set register=True to also copy the model into the "
+        "user's Processing models folder so it appears in the Processing Toolbox after refresh.\n\n"
+        "The response echoes 'resolved_steps' so the caller can verify which algorithm each hint mapped to."
+    ),
+    structured_output=True,
+)
+async def create_processing_model(
+    ctx: Context,
+    name: str,
+    steps: list[dict],
+    inputs: list[dict] | None = None,
+    outputs: list[dict] | None = None,
+    path: str | None = None,
+    description: str = "",
+    group: str = "Models",
+    register: bool = False,
+    overwrite: bool = False,
+) -> dict[str, Any]:
+    await ctx.info(f"Building Processing model: {name} ({len(steps)} step(s))")
+    params: dict[str, Any] = {
+        "name": name,
+        "steps": steps,
+        "description": description,
+        "group": group,
+        "register": register,
+        "overwrite": overwrite,
+    }
+    if inputs is not None:
+        params["inputs"] = inputs
+    if outputs is not None:
+        params["outputs"] = outputs
+    if path is not None:
+        params["path"] = path
+    return await _send("create_processing_model", params, timeout=TIMEOUT_LONG)
 
 
 # --- Rendering ---
@@ -1369,7 +1427,7 @@ QGIS MCP connects QGIS Desktop to LLMs via the Model Context Protocol.
 - **Labeling**: get_layer_labeling, set_layer_labeling (field, font_size, color)
 - **Canvas**: get_canvas_extent, set_canvas_extent, get_canvas_screenshot, get_canvas_scale, set_canvas_scale
 - **Raster**: get_raster_info
-- **Processing**: execute_processing, list_processing_algorithms, get_algorithm_help
+- **Processing**: execute_processing, list_processing_algorithms, get_algorithm_help, create_processing_model
 - **Rendering**: render_map (re-render to image), get_canvas_screenshot (fast grab)
 - **Code**: execute_code (arbitrary PyQGIS)
 - **Batch**: batch_commands (multiple commands in one round-trip)
@@ -1459,6 +1517,38 @@ def spatial_analysis_prompt(
             f"3. Check that CRS matches; if not, reproject one layer first\n"
             f"4. Use execute_processing with the appropriate algorithm (e.g. native:intersection, native:union)\n"
             f"5. Report the result layer's feature count and fields"
+        )
+    ]
+
+
+@mcp.prompt(
+    name="create_processing_model",
+    description="Translate a natural-language workflow description into a saved QGIS Processing Model",
+)
+def create_processing_model_prompt(
+    description: str, path: str | None = None
+) -> list[UserMessage]:
+    target = (
+        f"Save the model to: {path}."
+        if path
+        else "Ask the user where to save the model, or pass register=True to drop it into the user's Processing models folder."
+    )
+    return [
+        UserMessage(
+            content=(
+                "Build a QGIS Processing Model that implements this workflow:\n\n"
+                f"\"{description}\"\n\n"
+                "Call the `create_processing_model` tool ONCE. Algorithm lookup and parameter "
+                "validation happen inside the plugin against QGIS's Processing registry — do NOT "
+                "call `list_processing_algorithms` or `get_algorithm_help`. For each step pass a "
+                "concise `algorithm` keyword (e.g. 'buffer', 'centroids', 'clip') or a full id; "
+                "if a keyword is ambiguous the tool returns the candidate list so you can retry "
+                "with a more specific hint. Reference model inputs as '@name', earlier step "
+                "outputs as '$step_id.OUTPUT', and QGIS expressions as '=expr'. "
+                f"{target} "
+                "After the call, summarize the resolved_steps it returned so the user can verify "
+                "the algorithm choices."
+            )
         )
     ]
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -475,10 +475,10 @@ async def test_create_processing_model_tool(mock_connection):
         "status": "success",
         "result": {
             "ok": True,
-            "name": "buffer_centroids",
-            "path": "/tmp/buffer_centroids.model3",
-            "registered": False,
-            "registered_path": None,
+            "name": "buffer_centroids_2",
+            "requested_name": "buffer_centroids",
+            "path": "/home/u/.local/share/QGIS/QGIS3/profiles/default/processing/models/buffer_centroids_2.model3",
+            "registered": True,
             "input_count": 2,
             "step_count": 2,
             "output_count": 1,
@@ -511,12 +511,13 @@ async def test_create_processing_model_tool(mock_connection):
         steps=steps,
         inputs=inputs,
         outputs=outputs,
-        path="/tmp/buffer_centroids.model3",
     )
     assert output["ok"] is True
     assert output["step_count"] == 2
+    assert output["registered"] is True
+    assert output["requested_name"] == "buffer_centroids"
 
-    # Long timeout, full payload forwarded
+    # Long timeout, full payload forwarded — no path/register/overwrite fields anymore
     mock_connection.send_command.assert_called_once()
     call_args = mock_connection.send_command.call_args
     assert call_args[0][0] == "create_processing_model"
@@ -525,9 +526,9 @@ async def test_create_processing_model_tool(mock_connection):
     assert sent["steps"] == steps
     assert sent["inputs"] == inputs
     assert sent["outputs"] == outputs
-    assert sent["path"] == "/tmp/buffer_centroids.model3"
-    assert sent["register"] is False
-    assert sent["overwrite"] is False
+    assert "path" not in sent
+    assert "register" not in sent
+    assert "overwrite" not in sent
     # Uses the long timeout for processing operations
     assert call_args[1]["timeout"] == 60
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -470,6 +470,69 @@ async def test_list_processing_algorithms_tool(mock_connection):
 
 
 @pytest.mark.asyncio
+async def test_create_processing_model_tool(mock_connection):
+    mock_connection.send_command.return_value = {
+        "status": "success",
+        "result": {
+            "ok": True,
+            "name": "buffer_centroids",
+            "path": "/tmp/buffer_centroids.model3",
+            "registered": False,
+            "registered_path": None,
+            "input_count": 2,
+            "step_count": 2,
+            "output_count": 1,
+        },
+    }
+    from qgis_mcp.server import create_processing_model
+
+    ctx = _make_ctx()
+    inputs = [
+        {"name": "input_layer", "type": "vector", "description": "Input vector layer"},
+        {"name": "distance", "type": "distance", "default": 100},
+    ]
+    steps = [
+        {
+            "id": "buffer",
+            "algorithm": "native:buffer",
+            "parameters": {"INPUT": "@input_layer", "DISTANCE": "@distance", "DISSOLVE": False},
+        },
+        {
+            "id": "centroids",
+            "algorithm": "native:centroids",
+            "parameters": {"INPUT": "$buffer.OUTPUT", "ALL_PARTS": False},
+        },
+    ]
+    outputs = [{"name": "Centroids", "from_step": "centroids", "from_output": "OUTPUT"}]
+
+    output = await create_processing_model(
+        ctx,
+        name="buffer_centroids",
+        steps=steps,
+        inputs=inputs,
+        outputs=outputs,
+        path="/tmp/buffer_centroids.model3",
+    )
+    assert output["ok"] is True
+    assert output["step_count"] == 2
+
+    # Long timeout, full payload forwarded
+    mock_connection.send_command.assert_called_once()
+    call_args = mock_connection.send_command.call_args
+    assert call_args[0][0] == "create_processing_model"
+    sent = call_args[0][1]
+    assert sent["name"] == "buffer_centroids"
+    assert sent["steps"] == steps
+    assert sent["inputs"] == inputs
+    assert sent["outputs"] == outputs
+    assert sent["path"] == "/tmp/buffer_centroids.model3"
+    assert sent["register"] is False
+    assert sent["overwrite"] is False
+    # Uses the long timeout for processing operations
+    assert call_args[1]["timeout"] == 60
+
+
+@pytest.mark.asyncio
 async def test_get_algorithm_help_tool(mock_connection):
     mock_connection.send_command.return_value = {
         "status": "success",


### PR DESCRIPTION
## Summary

Adds a new MCP tool, `create_processing_model`, that builds a QGIS Processing Model (`.model3`) from a structured JSON spec, **always saves it into the QGIS user models folder, and registers it in the Processing Toolbox** — in a single round-trip, with all algorithm discovery and parameter validation happening inside the plugin against QGIS's live Processing registry.

## API shape

```python
create_processing_model(
    name: str,
    steps: list[dict],            # required
    inputs: list[dict] = None,
    outputs: list[dict] = None,   # if omitted, last step's OUTPUT is exposed as 'Result'
    description: str = "",
    group: str = "Models",
)
```

The model is always written into the QGIS user profile's Processing models folder and the model provider is refreshed so the model appears in the Toolbox immediately. If `<name>.model3` already exists in that folder, a numeric suffix is appended (`<name>_2.model3`, `<name>_3.model3`, …) and the actual filename used is returned to the caller, so the same `name` can safely be requested again across runs without overwriting prior work.

### Inputs

Supported input types: `vector`, `feature_source`, `raster`, `field` (requires `parent_layer`), `number`, `integer`, `distance` (optional `parent_layer`), `string`, `boolean`, `extent`, `crs`, `point`, `file`, `folder`, `enum` (with `options`), `multiple_layers`. Each input can declare `description`, `default`, and `optional`.

### Steps

Each step is `{id, algorithm, description?, parameters: {...}}`. The `algorithm` field accepts a fuzzy keyword (`"buffer"`, `"centroids"`, `"clip"`) or a full id (`"native:buffer"`). The handler:

- Matches the hint against algorithm ids, display names, and id suffixes.
- Disambiguates by preferring `native:` provider when there's a tie.
- On a still-ambiguous match, returns a candidate list (up to 8) so the caller can refine and retry — no half-written file.
- Validates every parameter name against the algorithm's actual parameter definitions before doing anything destructive.

### Reference syntax in step parameter values

| Form | Meaning |
|---|---|
| `"@input_name"` | Value of a model input |
| `"$step_id.OUTPUT_NAME"` | Output of a previous step |
| `"=expression"` | QGIS expression evaluated at runtime |
| anything else (number, bool, string, list, ...) | Static literal |

Lists are converted element-wise, so e.g. `PREDICATE: [0]` for `extractbylocation` works as a static list.

### Outputs

`outputs: [{name, from_step, from_output, description?}]`. Output names are validated against the source step's actual output definitions. If `outputs` is omitted, the last step's `OUTPUT` (or its first output) is exposed automatically under the name `"Result"`, so trivial models still produce something usable.

## Response

```json
{
  "ok": true,
  "name": "buffer_centroids_2",
  "requested_name": "buffer_centroids",
  "path": "/home/<user>/.local/share/QGIS/QGIS3/profiles/default/processing/models/buffer_centroids_2.model3",
  "registered": true,
  "input_count": 2,
  "step_count": 2,
  "output_count": 1,
  "resolved_steps": [
    {"id": "buffer", "algorithm": "native:buffer", "hint": "native:buffer"},
    {"id": "centroids", "algorithm": "native:centroids", "hint": "native:centroids"}
  ]
}
```

- `name` — the actual filename used (after collision-suffixing).
- `requested_name` — the original `name` argument; equal to `name` when no collision happened.
- `path` — full path to the written `.model3` file inside the QGIS models folder.
- `registered` — `true` once the provider's `refreshAlgorithms()` has succeeded.
- `resolved_steps` — fully-qualified algorithm id each fuzzy hint resolved to, so the caller can confirm without a follow-up call.

## Example

A two-step ``buffer → centroids`` model that the tool drops directly into the Toolbox:

```json
{
  "name": "buffer_centroids",
  "inputs": [
    {"name": "INPUT", "type": "feature_source", "description": "Input vector layer"},
    {"name": "DISTANCE", "type": "distance", "default": 100, "parent_layer": "INPUT"}
  ],
  "steps": [
    {"id": "buffer", "algorithm": "buffer",
     "parameters": {"INPUT": "@INPUT", "DISTANCE": "@DISTANCE"}},
    {"id": "centroids", "algorithm": "centroids",
     "parameters": {"INPUT": "$buffer.OUTPUT"}}
  ],
  "outputs": [
    {"name": "Centroids", "from_step": "centroids", "from_output": "OUTPUT"}
  ]
}
```

## Example prompts

These are the kind of natural-language requests an LLM client can fulfill end-to-end with a single `create_processing_model` call. They cover the main reference forms (`@input`, `$step.OUTPUT`, `=expression`) and the main input types (`feature_source`, `distance`, `field`, `raster`, `number`). The user does not need to specify a path: the model is always saved into the QGIS user models folder and registered in the Processing Toolbox.

**Two-step chain with a numeric parameter**
> Create a Processing Model called `dissolve_simplify` that dissolves all features of a vector layer into one and then simplifies the result with a given tolerance.

**Multi-input proximity workflow (uses `$step.OUTPUT` and a static-list predicate)**
> Create a Processing Model `points_near_roads` that takes a points layer and a roads layer plus a maximum distance, and returns only the points within that distance from any road.

**Field input with `parent_layer` and an aggregation algorithm**
> Create a Processing Model `count_points_in_polygons` that takes a polygons layer and a points layer, counts how many points fall in each polygon, and outputs the polygons with a new `n_points` attribute.

**Raster workflow with reclassification**
> Create a Processing Model `slope_classified` that takes a DEM raster, computes the slope in degrees, and reclassifies it into 3 classes (flat 0–5°, moderate 5–15°, steep >15°).

**Per-feature expression (uses `=expression` reference form)**
> Create a Processing Model `buffer_by_population` that takes a cities point layer and buffers each feature by a distance computed from its `population` field (e.g. `sqrt(population) * 10`).

The first two have been run end-to-end against the live plugin server during testing (see Test plan below); the rest are representative of the workflow shapes the tool is designed to handle.

## Companion changes

- **MCP prompt `create_processing_model`** — translates a natural-language workflow description into the right tool call
- **Compound-mode action** — `processing.create_model` exposes the same handler under the existing grouped Processing tool when `QGIS_MCP_TOOL_MODE=compound`.
- **`CLAUDE.md`** — tool count bumped to 52 and the new prompt documented.

## Files changed

| File | Change |
|---|---|
| `qgis_mcp_plugin/plugin.py` | New `create_processing_model` handler plus three helpers (`_resolve_algorithm_id`, `_build_param_source`, `_make_input_definition`); registered in the command dispatch table. Always writes into the user models folder and registers; collision-suffixes the filename. |
| `src/qgis_mcp/server.py` | New `create_processing_model` MCP tool and matching prompt. |
| `src/qgis_mcp/compound_tools.py` | New `create_model` action on the Processing compound tool. |
| `tests/test_mcp_tools.py` | Unit test verifying payload shape (no `path`/`register`/`overwrite`), long timeout, `requested_name` echo. |
| `CLAUDE.md` | Tool count + prompt entry. |

## Test plan

- [x] Added unit test `test_create_processing_model_tool` (mocked socket; verifies command name, payload contains no `path`/`register`/`overwrite`, 60s timeout, and `requested_name` is echoed).
- [x] Manually verified end-to-end against a running QGIS plugin server: a two-step `buffer → centroids` model registered into the user's models folder and surfaced in the Processing Toolbox; `resolved_steps` echoed correctly.
- [x] Manually verified a three-input model (`points_near_roads`: points, roads, distance) using the chain `native:buffer` → `native:extractbylocation` with a static-list `PREDICATE` parameter and a step-output reference.
- [ ] (Reviewer) Refresh the Processing Toolbox in QGIS and confirm the registered model is listed under the `Models` group and runs end-to-end. Confirm that calling the tool a second time with the same `name` produces a `_2`-suffixed model rather than overwriting the first one.
