### PR TITLE
fix(windows): MSIX Claude Desktop, junctions, and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,25 @@ Go to `Claude` > `Settings` > `Developer` > `Edit Config` and add:
   "mcpServers": {
     "qgis": {
       "command": "uv",
-      "args": ["run", "src/qgis_mcp/server.py"],
-      "cwd": "/path/to/qgis-mcp"
+      "args": [
+        "--directory", "/path/to/qgis-mcp",
+        "run", "src/qgis_mcp/server.py"
+      ]
     }
   }
 }
 ```
+
+> **Microsoft Store (MSIX) Claude Desktop on Windows:** the `--directory` form
+> shown above is required — `cwd` will not work. Store-installed Claude Desktop
+> runs MCP servers inside an MSIX package sandbox that silently drops the `cwd`
+> field, so configs using `cwd` fail with
+> `Failed to spawn: src/qgis_mcp/server.py — The system cannot find the path specified`.
+> Standalone (`.exe` from claude.ai) installs honor `cwd` fine; the
+> `--directory` form works in both, so it's the safer default. You can spot a
+> Store install when the config file lives under
+> `%LOCALAPPDATA%\Packages\Claude_<id>\LocalCache\Roaming\Claude\` instead of
+> the usual `%APPDATA%\Claude\`.
 
 Or for a remote install without cloning:
 

--- a/install.py
+++ b/install.py
@@ -134,10 +134,19 @@ def setup_venv() -> None:
 
 def _local_entry() -> dict:
     if shutil.which("uv"):
+        # `--directory` is preferred over `cwd` because some MCP clients (notably
+        # MSIX-packaged Claude Desktop on Windows) run servers in a sandbox that
+        # silently ignores `cwd`. `--directory` bakes the project path into the
+        # command itself so it works regardless of the spawn environment.
         return {
             "command": "uv",
-            "args": ["run", "--no-sync", "src/qgis_mcp/server.py"],
-            "cwd": str(REPO_DIR),
+            "args": [
+                "--directory",
+                str(REPO_DIR),
+                "run",
+                "--no-sync",
+                "src/qgis_mcp/server.py",
+            ],
         }
     # Fallback: run directly from the venv Python
     return {
@@ -158,7 +167,13 @@ def _zed_local_entry() -> dict:
         return {
             "command": {
                 "path": "uv",
-                "args": ["run", "--no-sync", "src/qgis_mcp/server.py"],
+                "args": [
+                    "--directory",
+                    str(REPO_DIR),
+                    "run",
+                    "--no-sync",
+                    "src/qgis_mcp/server.py",
+                ],
                 "env": {"QGIS_MCP_TRANSPORT": "stdio"},
             },
             "settings": {},
@@ -193,19 +208,34 @@ def _server_entry(client: str, remote: bool) -> dict:
 # ── Plugin installation ────────────────────────────────────────────────────
 
 
+def _remove_target(target: Path) -> None:
+    """Remove a plugin target — handles files, symlinks, Windows junctions, and dirs.
+
+    Path.is_symlink() returns False for Windows directory junctions (created via
+    `mklink /J`), so we also check os.path.islink() and fall back to rmdir() for
+    junctions before resorting to shutil.rmtree() on real directories.
+    """
+    if target.is_symlink() or os.path.islink(target) or target.is_file():
+        target.unlink()
+    elif sys.platform == "win32":
+        try:
+            target.rmdir()  # cleanly removes a junction without touching the target
+        except OSError:
+            shutil.rmtree(target)
+    else:
+        shutil.rmtree(target)
+
+
 def install_plugin(profile: str) -> Path:
     plugins_dir = qgis_plugins_dir(profile)
     target = plugins_dir / "qgis_mcp_plugin"
 
-    if target.is_symlink() or target.exists():
+    if target.is_symlink() or target.exists() or os.path.islink(target):
         if target.is_symlink() and target.resolve() == PLUGIN_SRC.resolve():
             print(f"  Plugin already linked: {target}")
             return target
         print(f"  Removing existing: {target}")
-        if target.is_symlink() or target.is_file():
-            target.unlink()
-        else:
-            shutil.rmtree(target)
+        _remove_target(target)
 
     plugins_dir.mkdir(parents=True, exist_ok=True)
 
@@ -224,11 +254,8 @@ def install_plugin(profile: str) -> Path:
 
 def uninstall_plugin(profile: str) -> None:
     target = qgis_plugins_dir(profile) / "qgis_mcp_plugin"
-    if target.is_symlink() or target.exists():
-        if target.is_symlink() or target.is_file():
-            target.unlink()
-        else:
-            shutil.rmtree(target)
+    if target.is_symlink() or target.exists() or os.path.islink(target):
+        _remove_target(target)
         print(f"  Removed: {target}")
     else:
         print(f"  Not installed: {target}")
@@ -265,8 +292,10 @@ def configure_client(client_name: str, remote: bool) -> None:
         if remote:
             cmd = f'claude mcp add qgis -- uvx --from "{GITHUB_URL}" qgis-mcp-server'
         elif shutil.which("uv"):
-            cmd = "claude mcp add qgis -- uv run --no-sync src/qgis_mcp/server.py"
-            print(f"  Run this from {REPO_DIR}:")
+            cmd = (
+                f'claude mcp add qgis -- uv --directory "{REPO_DIR}" '
+                "run --no-sync src/qgis_mcp/server.py"
+            )
         else:
             python = str(_venv_python())
             server = str(REPO_DIR / "src" / "qgis_mcp" / "server.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
 [project]
 name = "qgis-mcp"
 version = "0.2.1"
@@ -13,6 +17,12 @@ qgis-mcp-server = "qgis_mcp.server:main"
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0", "pytest-asyncio>=0.23"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/qgis_mcp"]
+
+[tool.uv]
+package = true
 
 [tool.ruff]
 target-version = "py312"

--- a/uv.lock
+++ b/uv.lock
@@ -540,8 +540,8 @@ wheels = [
 
 [[package]]
 name = "qgis-mcp"
-version = "0.1.1"
-source = { virtual = "." }
+version = "0.2.1"
+source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },
 ]


### PR DESCRIPTION
Three fixes for issues hit while installing on Windows. All three were independently reproducible while installing on a Windows + QGIS + Microsoft-Store-Claude-Desktop machine.

## 1. `pyproject.toml` — declare a build backend + uv package mode

Previously no `[build-system]` block, so `uv sync` falls back to legacy setuptools. On Python 3.13 Windows that hard-fails:

```
ImportError: cannot import name 'NoDefault' from '_typing' (unknown location)
```

Switching to hatchling sidesteps the bad legacy setuptools path entirely. Also added `[tool.uv] package = true` so `uv sync` actually does an editable install — without it, `from qgis_mcp.client import ...` in `server.py` raises `ModuleNotFoundError: No module named 'qgis_mcp'` because `src/` isn't on `sys.path` when the file is invoked directly.

## 2. `install.py` — handle Windows directory junctions on cleanup

`install_plugin()` falls back to `mklink /J` when `Path.symlink_to()` raises (which it does on Windows without admin or Developer Mode). On the next reinstall, `Path.is_symlink()` returns **False** for junctions, so the cleanup branch falls through to `shutil.rmtree(target)` — which raises `OSError: Cannot call rmtree on a symbolic link` because `os.path.islink()` (used internally by rmtree) **does** see junctions.

New `_remove_target()` helper checks `os.path.islink()` and uses `Path.rmdir()` (cleanly removes a junction without touching the target) before falling back to `rmtree()` for real directories. Also applied to `uninstall_plugin()`.

## 3. `install.py` + `README.md` — use `--directory` instead of `cwd`

MSIX-packaged Claude Desktop on Windows (the Microsoft Store install) runs MCP servers inside a packaged sandbox that **silently drops the `cwd` field**. The result is `uv` running from whatever the sandbox's spawn cwd happens to be, and:

```
error: Failed to spawn: `src/qgis_mcp/server.py`
  Caused by: The system cannot find the path specified. (os error 3)
```

The CONTRIBUTING.md already shows the `--directory` form, so this just brings README + the install.py-generated configs into line with that pattern. `--directory` works in both Store-packaged and standalone installs, on all platforms, so it's strictly safer than `cwd`.

Applied to `_local_entry()`, `_zed_local_entry()`, the `claude-code` print-only one-liner, and the manual-install snippet in README. Added a callout block in README explaining the MSIX detail (with the canonical config path under `%LOCALAPPDATA%\Packages\Claude_<id>\` so users can identify a Store install).

## Test plan

- [x] `uv sync` from a clean `.venv` succeeds on Linux + Python 3.13 with the new `[build-system]`
- [x] All 83 unit tests pass: `uv run --no-sync pytest tests/test_mcp_tools.py -v`
- [x] `python install.py --help` prints expected help
- [x] Originally tracked through to a working Claude Desktop ↔ QGIS connection on Jacob's Windows box (MSIX install, Python 3.12, fresh clone in user-writable dir) — that's where these three fixes were validated end-to-end
- [ ] Reviewer to verify on Windows with admin/Developer Mode (true symlinks, not junctions) that the junction-handling code path doesn't break the symlink case