### PR TITLE
fix(client): close socket on framed I/O errors to prevent recv-buffer desync

### DIFF
--- a/src/qgis_mcp/client.py
+++ b/src/qgis_mcp/client.py
@@ -103,13 +103,23 @@ class QgisMCPClient:
             return json.loads(resp_data)
 
         except TimeoutError:
+            # Frame state is unrecoverable: a delayed response may still
+            # arrive and pollute the recv buffer for the next call. Close
+            # the socket so the connection cache reconnects on the next call.
             logger.warning("Socket operation timed out after %ds", timeout)
-            return {"status": "error", "message": "Connection timed out"}
+            self.disconnect()
+            raise ConnectionError(f"Socket operation timed out after {timeout}s")
         except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, ConnectionError):
+            self.disconnect()
             raise  # Let callers handle reconnection
         except Exception as e:
+            # Any other exception during framed I/O (e.g. _recv_exact's
+            # "Response too large" guard, json errors, struct errors) leaves
+            # the socket in an unknown state — close it so we don't reuse a
+            # desynced stream on the next call.
             logger.exception("Error sending command")
-            return {"status": "error", "message": str(e)}
+            self.disconnect()
+            raise ConnectionError(f"Send command failed: {e}") from e
 
     # --- Convenience methods (existing) ---
 


### PR DESCRIPTION
## Summary

`QgisMCPClient.send_command` keeps the socket open after a framed read/write is interrupted (timeout, frame-size guard, json/struct error). Because the connection is cached and reused across tool calls (`server.get_qgis_connection`), the OS recv buffer can carry leftover bytes from a previous response into the next call. `_recv_exact(4)` then reads 4 bytes of ASCII JSON as a big-endian length, producing absurd payload lengths that trip the 100 MB safety cap.

In production this surfaces as a recurring error — every subsequent tool call fails until the plugin server is manually restarted:

```
Response too large: 2065855348 bytes (max 104857600)
```

## Root cause

Decoding the five distinct "too large" sizes observed in the field as big-endian 4-byte ASCII confirms each is a substring of a `{"status": "success", ...}` response that arrived after the previous request was abandoned:

| reported "size" | bytes (BE) | actual content |
|---|---|---|
| 2 065 855 348 | `{"st` | start of `{"status":...` |
| 1 937 072 995 | `succ` | inside `"success"` |
| 1 702 064 930 | `ess"` | end of `"success"` |
| 1 635 022 195 | `atus` | inside `"status"` |
|   574 234 658 | `": "` | JSON separator |

So the symptom is a buffered, late-arriving prior response — i.e. framing desync on a reused socket.

The trigger paths in `client.py`:

- `except TimeoutError` returned a structured error dict and kept the socket open.
- `except Exception`     returned a structured error dict and kept the socket open. This also swallowed `_recv_exact`'s own "Response too large" `ValueError`, so once desync started it stayed broken.
- `except (BrokenPipeError, ...)` re-raised but did not close.

`server.get_qgis_connection`'s validation only calls `getpeername()`, which doesn't see leftover bytes on the recv buffer, so the cached socket gets reused indefinitely.

## Fix

On any non-clean exit from `send_command`, `disconnect()` and re-raise as `ConnectionError`. `server._send_sync` already catches `(OSError, ConnectionError)`, invalidates the cached connection, and retries — so this routes timeouts and frame-corruption errors into the existing reconnect path with no other changes needed.

```python
except TimeoutError:
    self.disconnect()
    raise ConnectionError(f"Socket operation timed out after {timeout}s")
except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError, ConnectionError):
    self.disconnect()
    raise
except Exception as e:
    logger.exception("Error sending command")
    self.disconnect()
    raise ConnectionError(f"Send command failed: {e}") from e
```

## Behavior change

- `TimeoutError` previously bubbled up as `RuntimeError("Connection timed out")` via `_send_sync` and did **not** trigger a reconnect — the broken socket survived. Now it raises `ConnectionError`, which `_send_sync` already routes through `_invalidate_connection` + retry. End-result for the user: a transient timeout is recoverable; a persistent timeout still fails after `_MAX_RETRIES` attempts.
- Generic exceptions (json errors, struct errors, `_recv_exact` size-cap) used to be returned as `{"status": "error", "message": ...}` and reach the user as `RuntimeError(message)`. Now they raise `ConnectionError(message)` and the connection is recycled. Same user-visible message; recovery is automatic.

No protocol change, no plugin-side change.

## Test plan

- [ ] Unit: simulate timeout mid-recv → next `send_command` should succeed (currently fails with "Response too large").
- [ ] Unit: simulate `_recv_exact` size-cap trigger (e.g. a stub plugin sending a bogus length prefix) → next `send_command` should succeed after reconnect.
- [ ] Manual: kill QGIS plugin mid-render, then call `ping` — should reconnect cleanly without manual plugin restart.

I have not added test cases in this PR; happy to follow up with them if you'd like, or you can route this as fix-only.

## Discovery and authorship

The bug was discovered, root-caused (including the byte-pattern analysis above), and the patch was authored by **AI** — Anthropic's Claude — during a real session that hit the desync against a live QGIS plugin. A human (the fork owner) reviewed and authorized the fork, the fix, and this PR before submission.