### PR TITLE
fix: Qt6 Windows compatibility — supportsQt6=yes + QVariant type shim

### DIFF
--- a/qgis_mcp_plugin/compat.py
+++ b/qgis_mcp_plugin/compat.py
@@ -16,7 +16,7 @@ from qgis.core import (
     QgsRasterBandStats,
     QgsWkbTypes,
 )
-from qgis.PyQt.QtCore import QIODevice, Qt
+from qgis.PyQt.QtCore import QIODevice, Qt, QVariant
 from qgis.PyQt.QtWidgets import QToolButton
 
 # ── Layer types ──────────────────────────────────────────────────────

--- a/qgis_mcp_plugin/compat.py
+++ b/qgis_mcp_plugin/compat.py
@@ -108,3 +108,21 @@ try:
     TOOLBUTTON_ICON_ONLY = Qt.ToolButtonStyle.ToolButtonIconOnly
 except AttributeError:
     TOOLBUTTON_ICON_ONLY = Qt.ToolButtonIconOnly
+
+# ── QVariant type enums (PyQt6 moved these to QMetaType.Type) ────────
+try:
+    # PyQt6 / QGIS 4: QVariant.Type is an enum class
+    QVAR_STRING = QVariant.Type.String
+    QVAR_INT = QVariant.Type.Int
+    QVAR_DOUBLE = QVariant.Type.Double
+    QVAR_BOOL = QVariant.Type.Bool
+    QVAR_DATE = QVariant.Type.Date
+    QVAR_DATETIME = QVariant.Type.DateTime
+except AttributeError:
+    # PyQt5 / QGIS 3: QVariant members are direct attributes
+    QVAR_STRING = QVariant.String
+    QVAR_INT = QVariant.Int
+    QVAR_DOUBLE = QVariant.Double
+    QVAR_BOOL = QVariant.Bool
+    QVAR_DATE = QVariant.Date
+    QVAR_DATETIME = QVariant.DateTime

--- a/qgis_mcp_plugin/metadata.txt
+++ b/qgis_mcp_plugin/metadata.txt
@@ -31,6 +31,7 @@ category=Plugins
 icon=icons/icon.png
 experimental=False
 deprecated=False
+supportsQt6=yes
 changelog=0.2.1 : Fix installer auto-setup deps (pip fallback for Windows),
     QGIS 4.0 compat (tree node truthiness, message log signal),
     113 integration tests (TDD + stress + concurrency)

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -94,6 +94,12 @@ from .compat import (
     MSG_INFO,
     MSG_WARNING,
     PROCESSING_OPTIONAL,
+    QVAR_BOOL,
+    QVAR_DATE,
+    QVAR_DATETIME,
+    QVAR_DOUBLE,
+    QVAR_INT,
+    QVAR_STRING,
     RASTER_STATS_ALL,
     TOOLBUTTON_ICON_ONLY,
     TOOLBUTTON_MENU_POPUP,
@@ -1848,14 +1854,14 @@ class QgisMCPServer(QObject):
         layer = self._get_vector_layer(layer_id)
 
         type_map = {
-            "string": QVariant.String,
-            "int": QVariant.Int,
-            "double": QVariant.Double,
-            "bool": QVariant.Bool,
-            "date": QVariant.Date,
-            "datetime": QVariant.DateTime,
+            "string": QVAR_STRING,
+            "int": QVAR_INT,
+            "double": QVAR_DOUBLE,
+            "bool": QVAR_BOOL,
+            "date": QVAR_DATE,
+            "datetime": QVAR_DATETIME,
         }
-        v_type = type_map.get(field_type.lower(), QVariant.String)
+        v_type = type_map.get(field_type.lower(), QVAR_STRING)
         field = QgsField(field_name, v_type, field_type, length or 0, precision or 0)
 
         if layer.dataProvider().addAttributes([field]):


### PR DESCRIPTION
## Problem
QGIS builds with Qt6 (QGIS 3.34+/4.x on Windows) refuse to load this plugin with the error:
> *"Plugin does not support Qt6 versions of QGIS"*

This is because QGIS requires `supportsQt6=yes` in `metadata.txt` to explicitly declare Qt6 compatibility.

## Changes

### 1. `metadata.txt` — Add `supportsQt6=yes`
Required flag for QGIS Qt6 builds to load the plugin.

### 2. `compat.py` — QVariant type enum compatibility
PyQt6 moved `QVariant.String`, `QVariant.Int`, etc. to `QVariant.Type.String`, `QVariant.Type.Int`, etc. Added a try/except shim that resolves the correct value at import time (same pattern as the existing enum compatibility code).

### 3. `plugin.py` — Use compat constants in `add_field`
Replaced direct `QVariant.String` etc. references with the new compat constants (`QVAR_STRING`, `QVAR_INT`, etc.).

## Testing
- Plugin loads in QGIS 3.28+ with Qt6 on Windows
- All existing Qt5/PyQt5 builds continue to work (fallback in compat.py)
- `add_field` handler works with all field types on both Qt5 and Qt6