### PR TITLE
fix: use absolute uv path in generated MCP client configs

### DIFF
--- a/install.py
+++ b/install.py
@@ -133,9 +133,13 @@ def setup_venv() -> None:
 
 
 def _local_entry() -> dict:
-    if shutil.which("uv"):
+    uv = shutil.which("uv")
+    if uv:
+        # Use the resolved absolute path so the config works when spawned by MCP clients
+        # (e.g. Node.js-based clients like Claude Code) that inherit a stripped PATH which
+        # may not include the directory where uv is installed (~/.cargo/bin, ~/.local/bin, etc.)
         return {
-            "command": "uv",
+            "command": uv,
             "args": ["run", "--no-sync", "src/qgis_mcp/server.py"],
             "cwd": str(REPO_DIR),
         }
@@ -154,10 +158,11 @@ def _remote_entry() -> dict:
 
 
 def _zed_local_entry() -> dict:
-    if shutil.which("uv"):
+    uv = shutil.which("uv")
+    if uv:
         return {
             "command": {
-                "path": "uv",
+                "path": uv,  # absolute path — Zed spawns outside the user shell, same PATH issue
                 "args": ["run", "--no-sync", "src/qgis_mcp/server.py"],
                 "env": {"QGIS_MCP_TRANSPORT": "stdio"},
             },
@@ -264,8 +269,10 @@ def configure_client(client_name: str, remote: bool) -> None:
     if info.get("print_only"):
         if remote:
             cmd = f'claude mcp add qgis -- uvx --from "{GITHUB_URL}" qgis-mcp-server'
-        elif shutil.which("uv"):
-            cmd = "claude mcp add qgis -- uv run --no-sync src/qgis_mcp/server.py"
+        elif uv := shutil.which("uv"):
+            # Use the absolute path to uv — Claude Code spawns MCP servers via Node.js,
+            # which does not inherit the shell PATH, so bare "uv" will not resolve.
+            cmd = f'claude mcp add qgis --cwd "{REPO_DIR}" -- "{uv}" run --no-sync src/qgis_mcp/server.py'
             print(f"  Run this from {REPO_DIR}:")
         else:
             python = str(_venv_python())


### PR DESCRIPTION
## Problem

MCP clients (Claude Code, Cursor, Zed, VS Code Copilot) spawn the MCP server process via **Node.js**, which inherits a stripped-down `PATH` that typically does not include the user directories where `uv` is installed:

- Linux/macOS: `~/.local/bin`, `~/.cargo/bin`
- Windows: `%USERPROFILE%\.local\bin`, `%USERPROFILE%\.cargo\bin`

When `install.py` writes `"command": "uv"` (bare name) into the generated config, the command resolves fine when the user runs it from their own shell, but the MCP client's Node.js spawn silently fails — the process never starts, the tools are never registered, and there's no error message surfaced to the user.

This is a common class of bug for tools installed outside the system `PATH`. Confirmed on Windows 11 with `uv` installed via the official installer and Claude Code as the MCP client.

## Fix

Resolve the **full absolute path** to `uv` at install time via `shutil.which("uv")` and write that into the generated configs instead of the bare name `"uv"`. The existing `uv`-not-found fallback (use venv python directly) is unchanged.

Three places fixed in `install.py`:
- `_local_entry()` — configs for Claude Desktop, Cursor, VS Code
- `_zed_local_entry()` — Zed-specific config
- `configure_client()` claude-code branch — the printed `claude mcp add` command

The `--remote` / `uvx` paths are not changed (separate executable, same class of issue but out of scope here).

## Testing

Tested on Windows 11, uv at `C:\Users\Stuart\.local\bin\uv.exe`, Claude Code as the MCP client. Before this fix: server never started. After: server starts and all 51 tools register correctly.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)