### PR TITLE
feat: optional shared-secret socket authentication (QGIS_MCP_TOKEN)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ uv run --no-sync pytest tests/ -v
 |---|---|---|
 | `QGIS_MCP_HOST` | `localhost` | Host for QGIS plugin socket connection |
 | `QGIS_MCP_PORT` | `9876` | Port for QGIS plugin socket connection |
+| `QGIS_MCP_TOKEN` | _(unset)_ | Optional shared secret. When set, the plugin requires a matching `token` on every command (constant-time compare); the client attaches it automatically. Unset = no auth (default, backward-compatible). |
 | `QGIS_MCP_TRANSPORT` | `stdio` | MCP transport: `stdio` or `streamable-http` |
 | `QGIS_MCP_LOG_FILE` | `~/.local/share/qgis-mcp/server.log` | Log file path (empty to disable file logging) |
 | `QGIS_MCP_LOG_LEVEL` | `INFO` | File log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |

--- a/README.md
+++ b/README.md
@@ -182,10 +182,32 @@ Groups: `system`, `project`, `layer`, `features`, `selection`, `style`, `canvas`
 |---------------------|---------|-------------|
 | `QGIS_MCP_HOST` | `localhost` | Host for socket connection |
 | `QGIS_MCP_PORT` | `9876` | Port for socket connection |
+| `QGIS_MCP_TOKEN` | _(unset)_ | Optional shared secret. When set, the plugin rejects any command without a matching token. See [Authentication](#authentication). |
 | `QGIS_MCP_TRANSPORT` | `stdio` | MCP transport: `stdio` or `streamable-http` |
 | `QGIS_MCP_LOG_FILE` | `~/.local/share/qgis-mcp/server.log` | Log file path (empty to disable) |
 | `QGIS_MCP_LOG_LEVEL` | `INFO` | File log level |
 | `QGIS_MCP_TOOL_MODE` | `granular` | `granular` (102 tools) or `compound` (~23 grouped) |
+
+### Authentication
+
+By default the socket has **no authentication** — it binds to `localhost` only, but any process on the machine that can reach the port can drive QGIS (including `execute_code`, which runs arbitrary PyQGIS). For shared or multi-user machines, set a shared secret so only callers that know it can connect:
+
+1. Set `QGIS_MCP_TOKEN` in the **environment QGIS runs in** (so the plugin enforces it), then Stop/Start the server in the dock. The QGIS log shows `Token authentication ENABLED`.
+2. Set the **same** value in the MCP server's environment — add it to the `env` block of your MCP client config:
+
+   ```json
+   {
+     "mcpServers": {
+       "qgis": {
+         "command": "uvx",
+         "args": ["--from", "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip", "qgis-mcp-server"],
+         "env": { "QGIS_MCP_TOKEN": "your-long-random-secret" }
+       }
+     }
+   }
+   ```
+
+The token is compared in constant time. When `QGIS_MCP_TOKEN` is unset (the default), behaviour is unchanged. This raises the bar against other local users/processes; a process running as the same user can still read the token from your config, so it is not a sandbox.
 
 ## Contributing
 

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -4,6 +4,7 @@ import fnmatch
 import io
 import json
 import os
+import secrets
 import shutil
 import socket
 import struct
@@ -197,6 +198,12 @@ class QgisMCPServer(QObject):
             QgsMessageLog.logMessage(
                 f"QGIS MCP server started on {self.host}:{self.port}", self.LOG_TAG, MSG_INFO
             )
+            auth_on = bool(os.environ.get("QGIS_MCP_TOKEN", "").strip())
+            QgsMessageLog.logMessage(
+                f"Token authentication {'ENABLED' if auth_on else 'disabled (open)'}",
+                self.LOG_TAG,
+                MSG_INFO if auth_on else MSG_WARNING,
+            )
             return True
         except Exception as e:
             QgsMessageLog.logMessage(f"Failed to start server: {e!s}", self.LOG_TAG, MSG_CRITICAL)
@@ -314,6 +321,22 @@ class QgisMCPServer(QObject):
     def execute_command(self, command):
         """Execute a command"""
         try:
+            # Optional shared-secret auth. When QGIS_MCP_TOKEN is set in the
+            # plugin's environment, every command must carry a matching token;
+            # otherwise it is rejected before any handler runs. When the variable
+            # is unset, behaviour is unchanged (open) for backward compatibility.
+            expected_token = os.environ.get("QGIS_MCP_TOKEN", "").strip()
+            if expected_token:
+                provided_token = str(command.get("token") or "")
+                if not secrets.compare_digest(provided_token, expected_token):
+                    QgsMessageLog.logMessage(
+                        "Rejected command with missing/invalid token", self.LOG_TAG, MSG_WARNING
+                    )
+                    return {
+                        "status": "error",
+                        "message": "Authentication failed: missing or invalid token",
+                    }
+
             cmd_type = command.get("type")
             params = command.get("params", {})
 

--- a/src/qgis_mcp/client.py
+++ b/src/qgis_mcp/client.py
@@ -17,6 +17,7 @@ from qgis_mcp.helpers import (
     RECV_CHUNK_SIZE,
     TIMEOUT_DEFAULT,
     TIMEOUT_LONG,
+    get_auth_token,
 )
 
 logger = logging.getLogger("QgisMCPClient")
@@ -82,6 +83,12 @@ class QgisMCPClient:
             raise ConnectionError("Not connected to server")
 
         command = {"type": command_type, "params": params or {}}
+
+        # Attach the shared-secret token when QGIS_MCP_TOKEN is configured. No-op
+        # when auth is disabled, so existing setups are unaffected.
+        token = get_auth_token()
+        if token:
+            command["token"] = token
 
         try:
             data = json.dumps(command).encode("utf-8")

--- a/src/qgis_mcp/helpers.py
+++ b/src/qgis_mcp/helpers.py
@@ -5,6 +5,7 @@ Imports only from ``mcp`` and stdlib — no circular-import risk.
 
 import importlib.metadata
 import json
+import os
 import struct
 
 from mcp.types import Annotations, ImageContent, ResourceLink, TextContent
@@ -30,6 +31,18 @@ BATCH_BLOCKED_COMMANDS = frozenset(
         "reload_plugin",
     }
 )
+
+
+def get_auth_token():
+    """Return the shared-secret socket token, or ``None`` when auth is disabled.
+
+    Read from the ``QGIS_MCP_TOKEN`` environment variable. When unset or empty,
+    authentication is off and behaviour is unchanged — the plugin accepts any
+    command (the historical default). When set, the client attaches it to every
+    command and the plugin rejects commands that don't present a matching token.
+    """
+    token = os.environ.get("QGIS_MCP_TOKEN", "").strip()
+    return token or None
 
 
 def enrich_diagnose(result: dict) -> dict:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,5 +1,6 @@
 """Unit tests for MCP server tools with mocked socket connection."""
 
+import json
 import os
 import sys
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,6 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
 
+from qgis_mcp.helpers import HEADER_STRUCT, get_auth_token
 from qgis_mcp.server import QgisMCPClient, _send_sync
 
 # --- Fixtures ---
@@ -1858,3 +1860,56 @@ def test_compound_tools_register():
 
     # Should have registered ~19 compound tools (15 main + 4 additional)
     assert mock_mcp.tool.call_count >= 14
+
+
+# --- Optional shared-secret auth (QGIS_MCP_TOKEN) ---
+
+
+def test_get_auth_token_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("QGIS_MCP_TOKEN", raising=False)
+    assert get_auth_token() is None
+    # Whitespace-only is treated as unset.
+    monkeypatch.setenv("QGIS_MCP_TOKEN", "   ")
+    assert get_auth_token() is None
+
+
+def test_get_auth_token_when_set(monkeypatch):
+    monkeypatch.setenv("QGIS_MCP_TOKEN", "s3cr3t")
+    assert get_auth_token() == "s3cr3t"
+
+
+def _client_capturing_send(response):
+    """A QgisMCPClient whose socket captures sent bytes and returns a framed
+    response, so we can inspect the exact command payload that was sent."""
+    client = QgisMCPClient()
+    client.socket = MagicMock()
+    sent = bytearray()
+    client.socket.sendall.side_effect = lambda b: sent.extend(b)
+
+    resp_bytes = json.dumps(response).encode("utf-8")
+    frames = [HEADER_STRUCT.pack(len(resp_bytes)), resp_bytes]
+
+    def fake_recv_exact(n):
+        return frames.pop(0)
+
+    client._recv_exact = fake_recv_exact  # type: ignore[method-assign]
+    return client, sent
+
+
+def _sent_command(sent):
+    """Decode the JSON command from captured (header + payload) bytes."""
+    return json.loads(bytes(sent)[4:].decode("utf-8"))
+
+
+def test_send_command_attaches_token_when_set(monkeypatch):
+    monkeypatch.setenv("QGIS_MCP_TOKEN", "tok123")
+    client, sent = _client_capturing_send({"status": "success", "result": {}})
+    client.send_command("ping")
+    assert _sent_command(sent)["token"] == "tok123"
+
+
+def test_send_command_omits_token_when_unset(monkeypatch):
+    monkeypatch.delenv("QGIS_MCP_TOKEN", raising=False)
+    client, sent = _client_capturing_send({"status": "success", "result": {}})
+    client.send_command("ping")
+    assert "token" not in _sent_command(sent)


### PR DESCRIPTION
## Summary

The plugin socket has no authentication today. It binds to `localhost` (good — no remote access), but any local process/user that can reach the port can drive QGIS, including `execute_code` (arbitrary PyQGIS). On shared or multi-user machines that's a gap.

This adds **opt-in** shared-secret auth via a `QGIS_MCP_TOKEN` environment variable. Fully backward-compatible: when it's unset (the default), behaviour is unchanged.

## How it works

- `helpers.get_auth_token()` — single source of truth; reads `QGIS_MCP_TOKEN` (empty/whitespace = off).
- `client.send_command()` — attaches the token to every command when set. One injection point covers all 102 tools and both `stdio`/`streamable-http` transports.
- `plugin.execute_command()` — when `QGIS_MCP_TOKEN` is set in the plugin's environment, rejects any command without a matching token (constant-time `secrets.compare_digest`) before dispatch; logs auth status (ENABLED/disabled) on Start. The token value itself is never logged.

## Testing

- 4 new unit tests in `tests/test_mcp_tools.py` (token reader + client attaches/omits token). Full mocked suite: **113 passed**.
- Plugin-side enforcement verified against a live **QGIS 4.0.2**: reject-missing, reject-wrong, accept-correct, open-when-unset.
- `ruff check` and `flake8 --select=W503` clean on the changed files.

## Notes / follow-ups

- Kept intentionally focused per CONTRIBUTING. **No version bump** — left to your release process (the 3-file sync in CLAUDE.md).
- Possible follow-up: a dock-widget field to set/generate the token from the UI (currently env-var only). Happy to add here or in a separate PR if you'd like it.
- The README documents the threat model honestly: this raises the bar against other local users/processes; a process running as the same user can still read the token from your config, so it is not a sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
