### PR TITLE
fix(plugin): support datetime.UTC on Python 3.9

### DIFF
--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -11,9 +11,16 @@ import struct
 import sys
 import traceback
 from collections import deque
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import ClassVar
+
+# Compatibility for different python versions
+try:
+    from datetime import UTC, datetime
+except ImportError:
+    from datetime import datetime, timezone
+
+    UTC = timezone.utc
 
 from qgis.core import (
     Qgis,


### PR DESCRIPTION
QGIS 3.32 on macOS ships Python 3.9, which lacks datetime.UTC (added in 3.11). Fall back to timezone.utc so the plugin loads on older runtimes.

Fixes #3