### PR TITLE
feat(3d): add get_3d_screenshot tool to capture an open 3D Map View

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package = true
 
 [project]
 name = "qgis-mcp"
-version = "0.5.1"
+version = "0.5.2"
 description = "QGIS integration through the Model Context Protocol"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ package = true
 
 [project]
 name = "qgis-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "QGIS integration through the Model Context Protocol"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/qgis_mcp_plugin/metadata.txt
+++ b/qgis_mcp_plugin/metadata.txt
@@ -19,7 +19,7 @@ about=Socket server plugin that exposes QGIS operations to LLMs through the
     - Non-blocking TCP socket server with length-prefixed framing
     - Toolbar button with port configuration dropdown
 
-version=0.5.1
+version=0.5.2
 author=Nicolas Karasiak
 email=nicart@gmail.com
 tags=mcp,ai,claude,llm,automation,socket,remote

--- a/qgis_mcp_plugin/metadata.txt
+++ b/qgis_mcp_plugin/metadata.txt
@@ -19,7 +19,7 @@ about=Socket server plugin that exposes QGIS operations to LLMs through the
     - Non-blocking TCP socket server with length-prefixed framing
     - Toolbar button with port configuration dropdown
 
-version=0.5.0
+version=0.5.1
 author=Nicolas Karasiak
 email=nicart@gmail.com
 tags=mcp,ai,claude,llm,automation,socket,remote

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -2068,7 +2068,9 @@ class QgisMCPServer(QObject):
             "height": pixmap.height(),
         }
 
-    def get_3d_screenshot(self, view_index=0, dpi=96, **kwargs):
+    def get_3d_screenshot(
+        self, view_index=0, dpi=96, pitch=None, distance=None, heading=None, **kwargs
+    ):
         """Capture an open 3D Map View as a PNG image.
 
         The 3D map view is an OpenGL ``QWindow`` that ``QWidget.grab()`` cannot
@@ -2076,6 +2078,11 @@ class QgisMCPServer(QObject):
         renders them through a print layout's 3D map item (whose offscreen 3D
         engine runs in C++). Requires a 3D map view to be open
         (View > 3D Map Views > New 3D Map View).
+
+        Optional ``pitch`` (0 = straight down / top-down, 90 = horizontal /
+        edge-on; ~45 is a balanced oblique), ``heading`` (compass degrees), and
+        ``distance`` (metres) override the captured camera angle without changing
+        the live view.
         """
         view_index = int(view_index)
         dpi = max(10, min(int(dpi), 600))  # clamp: bound render cost / memory use
@@ -2102,6 +2109,15 @@ class QgisMCPServer(QObject):
         # mutated or shared, and snapshot its current camera pose.
         map_settings = Qgs3DMapSettings(canvas3d.mapSettings())
         pose = canvas3d.cameraController().cameraPose()
+
+        # Optional camera overrides — applied only to this captured copy, so the
+        # live 3D view is left untouched.
+        if pitch is not None:
+            pose.setPitchAngle(max(0.0, min(float(pitch), 90.0)))
+        if heading is not None:
+            pose.setHeadingAngle(float(heading) % 360.0)
+        if distance is not None and float(distance) > 0:
+            pose.setDistanceFromCenterPoint(float(distance))
 
         # Match the output image to the 3D view's aspect ratio.
         size = canvas3d.size()

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -9,6 +9,7 @@ import shutil
 import socket
 import struct
 import sys
+import tempfile
 import traceback
 from collections import deque
 from datetime import UTC, datetime
@@ -84,7 +85,7 @@ from qgis.PyQt.QtCore import (
     QUrl,
     QVariant,
 )
-from qgis.PyQt.QtGui import QColor, QDesktopServices, QIcon, QPainter, QPen
+from qgis.PyQt.QtGui import QColor, QDesktopServices, QIcon, QImage, QPainter, QPen
 from qgis.PyQt.QtWidgets import (
     QAction,
     QCheckBox,
@@ -464,6 +465,8 @@ class QgisMCPServer(QObject):
                 "identify_features": self.identify_features,
                 "duplicate_layer": self.duplicate_layer,
                 "set_layer_order": self.set_layer_order,
+                # Phase 9 — 3D
+                "get_3d_screenshot": self.get_3d_screenshot,
             }
 
             handler = handlers.get(cmd_type)
@@ -2063,6 +2066,84 @@ class QgisMCPServer(QObject):
             "mime_type": "image/png",
             "width": pixmap.width(),
             "height": pixmap.height(),
+        }
+
+    def get_3d_screenshot(self, view_index=0, dpi=96, **kwargs):
+        """Capture an open 3D Map View as a PNG image.
+
+        The 3D map view is an OpenGL ``QWindow`` that ``QWidget.grab()`` cannot
+        read, so this reuses the open view's scene settings + camera pose and
+        renders them through a print layout's 3D map item (whose offscreen 3D
+        engine runs in C++). Requires a 3D map view to be open
+        (View > 3D Map Views > New 3D Map View).
+        """
+        view_index = int(view_index)
+        dpi = max(10, min(int(dpi), 600))  # clamp: bound render cost / memory use
+        try:
+            from qgis._3d import Qgs3DMapSettings, QgsLayoutItem3DMap
+        except ImportError as e:
+            raise Exception(
+                f"3D support is unavailable in this QGIS build (qgis._3d import failed: {e})"
+            ) from e
+
+        views = self.iface.mapCanvases3D()
+        if not views:
+            raise Exception(
+                "No 3D map view is open. Open one via "
+                "View > 3D Map Views > New 3D Map View, frame your scene, then retry."
+            )
+        if view_index < 0 or view_index >= len(views):
+            raise ValueError(
+                f"view_index {view_index} out of range (open 3D views: {len(views)})"
+            )
+        canvas3d = views[view_index]
+
+        # Clone the scene settings (copy constructor) so the live view is never
+        # mutated or shared, and snapshot its current camera pose.
+        map_settings = Qgs3DMapSettings(canvas3d.mapSettings())
+        pose = canvas3d.cameraController().cameraPose()
+
+        # Match the output image to the 3D view's aspect ratio.
+        size = canvas3d.size()
+        view_w = max(1, size.width())
+        view_h = max(1, size.height())
+        page_w = 200.0
+        page_h = page_w * view_h / view_w
+
+        layout = QgsPrintLayout(QgsProject.instance())
+        layout.initializeDefaults()
+        layout.pageCollection().page(0).setPageSize(QgsLayoutSize(page_w, page_h))
+
+        item = QgsLayoutItem3DMap(layout)
+        item.attemptMove(QgsLayoutPoint(0, 0))
+        item.attemptResize(QgsLayoutSize(page_w, page_h))
+        item.setMapSettings(map_settings)
+        item.setCameraPose(pose)
+        layout.addLayoutItem(item)
+
+        tmp = os.path.join(tempfile.gettempdir(), f"mcp_3d_{secrets.token_hex(6)}.png")
+        try:
+            exporter = QgsLayoutExporter(layout)
+            export_settings = QgsLayoutExporter.ImageExportSettings()
+            export_settings.dpi = dpi
+            result = exporter.exportToImage(tmp, export_settings)
+            if int(result) != int(LAYOUT_SUCCESS) or not os.path.exists(tmp):
+                raise Exception(f"3D layout export failed (export code {int(result)})")
+            with open(tmp, "rb") as fh:
+                data = fh.read()
+        finally:
+            with contextlib.suppress(Exception):
+                os.remove(tmp)
+
+        img = QImage()
+        img.loadFromData(data, "PNG")
+        return {
+            "base64_data": base64.b64encode(data).decode("ascii"),
+            "mime_type": "image/png",
+            "width": img.width(),
+            "height": img.height(),
+            "view_index": view_index,
+            "open_3d_views": len(views),
         }
 
     def transform_coordinates(

--- a/src/qgis_mcp/compound_tools.py
+++ b/src/qgis_mcp/compound_tools.py
@@ -366,8 +366,9 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
             "- set_extent: xmin (float), ymin (float), xmax (float), ymax (float), "
             "crs (str, optional)\n"
             "- screenshot: no params — returns inline image\n"
-            "- screenshot_3d: view_index (int, optional), dpi (int, optional) — "
-            "capture an open 3D map view as an inline image\n"
+            "- screenshot_3d: view_index (int, optional), dpi (int, optional), "
+            "pitch (float, optional: 0=top-down, 90=edge-on), distance (float, optional), "
+            "heading (float, optional) — capture an open 3D map view as an inline image\n"
             "- get_scale: no params\n"
             "- set_scale: scale (float, optional), rotation (float, optional)"
         ),
@@ -397,11 +398,11 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
                 )
             ]
         elif action == "screenshot_3d":
-            params = {}
-            if "view_index" in kwargs:
-                params["view_index"] = kwargs["view_index"]
-            if "dpi" in kwargs:
-                params["dpi"] = kwargs["dpi"]
+            params = {
+                k: kwargs[k]
+                for k in ("view_index", "dpi", "pitch", "distance", "heading")
+                if k in kwargs
+            }
             result = await _send("get_3d_screenshot", params)
             return [
                 ImageContent(

--- a/src/qgis_mcp/compound_tools.py
+++ b/src/qgis_mcp/compound_tools.py
@@ -361,11 +361,13 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
         title="Canvas",
         description=(
             "Map canvas operations.\n"
-            "Actions: get_extent, set_extent, screenshot, get_scale, set_scale\n"
+            "Actions: get_extent, set_extent, screenshot, screenshot_3d, get_scale, set_scale\n"
             "- get_extent: no params\n"
             "- set_extent: xmin (float), ymin (float), xmax (float), ymax (float), "
             "crs (str, optional)\n"
             "- screenshot: no params — returns inline image\n"
+            "- screenshot_3d: view_index (int, optional), dpi (int, optional) — "
+            "capture an open 3D map view as an inline image\n"
             "- get_scale: no params\n"
             "- set_scale: scale (float, optional), rotation (float, optional)"
         ),
@@ -386,6 +388,21 @@ def register_compound_tools(mcp: FastMCP, _send, _confirm_destructive):
             return await _send("set_canvas_extent", params)
         elif action == "screenshot":
             result = await _send("get_canvas_screenshot")
+            return [
+                ImageContent(
+                    type="image",
+                    data=result["base64_data"],
+                    mimeType="image/png",
+                    annotations=Annotations(audience=["user", "assistant"], priority=1.0),
+                )
+            ]
+        elif action == "screenshot_3d":
+            params = {}
+            if "view_index" in kwargs:
+                params["view_index"] = kwargs["view_index"]
+            if "dpi" in kwargs:
+                params["dpi"] = kwargs["dpi"]
+            result = await _send("get_3d_screenshot", params)
             return [
                 ImageContent(
                     type="image",

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -722,6 +722,27 @@ async def get_canvas_screenshot(ctx: Context) -> list:
     ]
 
 
+@mcp.tool(
+    title="Get 3D Screenshot",
+    annotations=ToolAnnotations(readOnlyHint=True),
+    description="Capture an OPEN 3D Map View as an inline image. Reuses the open view's "
+    "scene + camera, rendered via a print-layout 3D map item (the 2D get_canvas_screenshot "
+    "cannot capture the OpenGL 3D view). Requires a 3D map view to be open in QGIS "
+    "(View > 3D Map Views > New 3D Map View). view_index selects which view when several "
+    "are open; dpi controls output resolution.",
+)
+async def get_3d_screenshot(ctx: Context, view_index: int = 0, dpi: int = 96) -> list:
+    result = await _send("get_3d_screenshot", {"view_index": view_index, "dpi": dpi})
+    return [
+        ImageContent(
+            type="image",
+            data=result["base64_data"],
+            mimeType="image/png",
+            annotations=Annotations(audience=["user", "assistant"], priority=1.0),
+        )
+    ]
+
+
 # --- Raster ---
 
 

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -729,10 +729,27 @@ async def get_canvas_screenshot(ctx: Context) -> list:
     "scene + camera, rendered via a print-layout 3D map item (the 2D get_canvas_screenshot "
     "cannot capture the OpenGL 3D view). Requires a 3D map view to be open in QGIS "
     "(View > 3D Map Views > New 3D Map View). view_index selects which view when several "
-    "are open; dpi controls output resolution.",
+    "are open; dpi controls output resolution. Optional camera overrides (applied to the "
+    "capture only, leaving the live view unchanged): pitch (0 = straight down/top-down, "
+    "90 = horizontal/edge-on; ~45 = balanced oblique), heading (compass degrees), "
+    "distance (metres).",
 )
-async def get_3d_screenshot(ctx: Context, view_index: int = 0, dpi: int = 96) -> list:
-    result = await _send("get_3d_screenshot", {"view_index": view_index, "dpi": dpi})
+async def get_3d_screenshot(
+    ctx: Context,
+    view_index: int = 0,
+    dpi: int = 96,
+    pitch: float | None = None,
+    distance: float | None = None,
+    heading: float | None = None,
+) -> list:
+    params: dict[str, Any] = {"view_index": view_index, "dpi": dpi}
+    if pitch is not None:
+        params["pitch"] = pitch
+    if distance is not None:
+        params["distance"] = distance
+    if heading is not None:
+        params["heading"] = heading
+    result = await _send("get_3d_screenshot", params)
     return [
         ImageContent(
             type="image",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -950,6 +950,34 @@ async def test_get_3d_screenshot_tool(mock_connection):
 
 
 @pytest.mark.asyncio
+async def test_get_3d_screenshot_camera_params(mock_connection):
+    mock_connection.send_command.return_value = {
+        "status": "success",
+        "result": {
+            "base64_data": "iVBOR==",
+            "mime_type": "image/png",
+            "width": 800,
+            "height": 600,
+            "view_index": 1,
+            "open_3d_views": 2,
+        },
+    }
+    from qgis_mcp.server import get_3d_screenshot
+
+    ctx = _make_ctx()
+    result = await get_3d_screenshot(
+        ctx, view_index=1, dpi=120, pitch=45, distance=2000, heading=30
+    )
+    assert result[0].type == "image"
+    # camera overrides are forwarded only when provided
+    mock_connection.send_command.assert_called_once_with(
+        "get_3d_screenshot",
+        {"view_index": 1, "dpi": 120, "pitch": 45, "distance": 2000, "heading": 30},
+        timeout=30,
+    )
+
+
+@pytest.mark.asyncio
 async def test_transform_coordinates_point(mock_connection):
     mock_connection.send_command.return_value = {
         "status": "success",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -928,6 +928,28 @@ async def test_get_canvas_screenshot_tool(mock_connection):
 
 
 @pytest.mark.asyncio
+async def test_get_3d_screenshot_tool(mock_connection):
+    mock_connection.send_command.return_value = {
+        "status": "success",
+        "result": {
+            "base64_data": "iVBOR==",
+            "mime_type": "image/png",
+            "width": 800,
+            "height": 600,
+            "view_index": 0,
+            "open_3d_views": 1,
+        },
+    }
+    from qgis_mcp.server import get_3d_screenshot
+
+    ctx = _make_ctx()
+    result = await get_3d_screenshot(ctx, view_index=0, dpi=96)
+    assert isinstance(result, list)
+    assert result[0].type == "image"
+    assert result[0].data == "iVBOR=="
+
+
+@pytest.mark.asyncio
 async def test_transform_coordinates_point(mock_connection):
     mock_connection.send_command.return_value = {
         "status": "success",

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "qgis-mcp"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },

--- a/uv.lock
+++ b/uv.lock
@@ -540,7 +540,7 @@ wheels = [
 
 [[package]]
 name = "qgis-mcp"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## What
Adds a `get_3d_screenshot` MCP tool that captures an **open 3D Map View** as an inline PNG — the 3D analogue of `get_canvas_screenshot`.

## Why
`get_canvas_screenshot` uses `QWidget.grab()`, which returns blank for the 3D Map View because it is an OpenGL `QWindow`. On QGIS 4.0.2 (Qt6) the Python bindings expose **no 3D engine class and no `Qgs3DUtils`**, so the usual `requestCaptureImage()` / `captureSceneImage()` paths are unavailable, and `QScreen.grabWindow()` of the GL surface returns black.

## How
Reuse an open 3D view's `mapSettings()` + `cameraController().cameraPose()`, render them through a print-layout `QgsLayoutItem3DMap` (whose offscreen 3D engine runs in C++, sidestepping the missing Python bindings), and export to PNG. Validated live on QGIS 4.0.2 — renders correctly in ~1–3 s.

## Changes
- `qgis_mcp_plugin/plugin.py`: `get_3d_screenshot` handler
- `src/qgis_mcp/server.py`: granular `get_3d_screenshot` tool (read-only)
- `src/qgis_mcp/compound_tools.py`: `screenshot_3d` action on the `canvas` compound tool (works under `QGIS_MCP_TOOL_MODE=compound`)
- `tests/test_mcp_tools.py`: `test_get_3d_screenshot_tool`
- version 0.5.0 → 0.5.1

## Safety
- Read-only; **clones** scene settings (never mutates the live view); transient layout (not registered with the layout manager)
- **Avoids `QgsMapLayer.setRenderer3D`**, which was observed to hard-crash QGIS 4.0.2 with an access violation
- `dpi` clamped to `[10, 600]`; `view_index` bounds-checked; random temp filename with guaranteed cleanup
- Lazy `qgis._3d` import → clean error message on builds without 3D support

## Tested
- ruff + flake8 (incl. W503) clean; 114 unit tests pass
- Exact handler body executed against a live 3D view: dpi clamp, success-code match, temp-file cleanup, valid PNG returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
