### PR TITLE
Fix zed integration

### DIFF
--- a/install.py
+++ b/install.py
@@ -181,46 +181,7 @@ def _remote_entry() -> dict:
     }
 
 
-def _zed_local_entry() -> dict:
-    if shutil.which("uv"):
-        return {
-            "command": {
-                "path": "uv",
-                "args": [
-                    "--directory",
-                    str(REPO_DIR),
-                    "run",
-                    "--no-sync",
-                    "src/qgis_mcp/server.py",
-                ],
-                "env": {"QGIS_MCP_TRANSPORT": "stdio"},
-            },
-            "settings": {},
-        }
-    return {
-        "command": {
-            "path": str(_venv_python()),
-            "args": [str(REPO_DIR / "src" / "qgis_mcp" / "server.py")],
-            "env": {"QGIS_MCP_TRANSPORT": "stdio"},
-        },
-        "settings": {},
-    }
-
-
-def _zed_remote_entry() -> dict:
-    return {
-        "command": {
-            "path": "uvx",
-            "args": ["--from", GITHUB_URL, "qgis-mcp-server"],
-            "env": {"QGIS_MCP_TRANSPORT": "stdio"},
-        },
-        "settings": {},
-    }
-
-
 def _server_entry(client: str, remote: bool) -> dict:
-    if client == "zed":
-        return _zed_remote_entry() if remote else _zed_local_entry()
     return _remote_entry() if remote else _local_entry()
 
 

--- a/install.py
+++ b/install.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import subprocess
 import sys
+import re
 from pathlib import Path
 
 REPO_DIR = Path(__file__).resolve().parent
@@ -246,12 +247,43 @@ def uninstall_plugin(profile: str, version: str = "auto") -> None:
 
 # ── Client configuration ───────────────────────────────────────────────────
 
+def _jsonc_to_json(text) -> str:
+    """Convert potential JSONC json file to valid JSON
+
+    Cases:
+        - A: JSONC with multi-line comments
+        - B: JSONC with single-line comment
+        - C: URLs with `http://`, `https://` preserved
+        - D: // inside string values preserved
+        - E: Trailing commas in objects and arrays
+    """
+    caseA = re.sub(r'/\*.*?\*/', '', text, flags=re.DOTALL)
+    casesBCD = re.sub(
+        r'("(?:\\.|[^"\\])*")|//.*',
+        lambda m: m.group(1) or '',
+        caseA,
+        flags=re.MULTILINE
+    )
+    caseE = re.sub(r',\s*([}\]])', r'\1', casesBCD)
+    return caseE
 
 def _read_json(path: Path) -> dict:
-    if path.exists():
-        text = path.read_text(encoding="utf-8").strip()
-        return json.loads(text) if text else {}
-    return {}
+    if not path.exists() or not (text := path.read_text(encoding="utf-8").strip()):
+        return {}
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    try:
+        cleaned = _jsonc_to_json(text)
+        return json.loads(cleaned)
+    except json.JSONDecodeError as e:
+        raise ValueError(
+            f"Failed to parse {path}: not valid JSON or JSONC. "
+            f"Error: {e}"
+        ) from e
 
 
 def _backup(path: Path) -> None:

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -3196,16 +3196,11 @@ def _client_config_registry(repo_dir):
 
 
 def _qgis_entry_command_args(entry):
-    """Return (command, args) for a 'qgis' server entry, handling the zed shape.
-
-    Zed nests {'command': {'path': ..., 'args': [...]}}; others use a flat
-    {'command': 'uvx', 'args': [...]}.
+    """Return (command, args) for a 'qgis' server entry.
     """
     if not isinstance(entry, dict):
         return None, []
     cmd = entry.get("command")
-    if isinstance(cmd, dict):  # zed
-        return cmd.get("path"), cmd.get("args", [])
     return cmd, entry.get("args", [])
 
 
@@ -3457,15 +3452,6 @@ class MCPConfiguratorDialog(QDialog):
                     "args": [str(self.repo_dir / "src" / "qgis_mcp" / "server.py")],
                 }
 
-        if client == "zed":
-            return {
-                "command": {
-                    "path": entry["command"],
-                    "args": entry["args"],
-                    "env": {"QGIS_MCP_TRANSPORT": "stdio"},
-                },
-                "settings": {},
-            }
         if client == "opencode":
             return {
                 "type": "local",


### PR DESCRIPTION
For Zed [1.8.2](https://github.com/zed-industries/zed/releases/tag/v1.8.2) 
Commit:  5e33fc855f6fe58dd82ed6acb1f58034c3fb6bac
Version: 1.8.2+stable.314.5e33fc855f6fe58dd82ed6acb1f58034c3fb6bac

- Remove overrides (in plugin.py and install.py)
Fixes:
<img width="1327" height="559" alt="image" src="https://github.com/user-attachments/assets/605f5d0c-d7f0-4e5f-b9a4-60c2dd152946" />



- Support JSONC by diluting it back to JSON (ZED's config settings is in JSONC and a basic JSON parser was failing)
Fixes:
```
  File "/home/..../..../qgis-mcp/install.py", line 292, in _read_json
    return **json.loads(text)** if text else {}
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise **JSONDecodeError**("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

When settings look like:
```
// Zed settings
//
// For a full list of overridable settings, and general information on folder-specific settings,
// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
{
  "disable_ai": false,
  "context_servers": {
    "mcp-server-github": {
      "enabled": true,
      "remote": false,
....
```