### PR TITLE
fix(plugin): set_layer_order reorders the tree instead of freezing custom draw order

### DIFF
--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -2934,17 +2934,38 @@ class QgisMCPServer(QObject):
         return {"ok": True, "output_layer_id": clone.id(), "name": clone.name()}
 
     def set_layer_order(self, layer_ids, **kwargs):
-        """Set explicit layer draw order in the tree (top to bottom)."""
+        """Reorder layer tree nodes (top to bottom); tree order is draw order.
+
+        Listed layers are rearranged into the given order within their common
+        parent; unlisted siblings keep their slots. Deliberately does NOT use
+        QGIS's custom draw order — that freezes a snapshot list, so any layer
+        added afterwards would silently draw behind everything; any existing
+        custom order is cleared for the same reason.
+        """
         project = QgsProject.instance()
         root = project.layerTreeRoot()
-        layers = []
+        nodes = []
         for lid in layer_ids:
-            lyr = project.mapLayer(lid)
-            if lyr is None:
-                raise Exception(f"Layer not found: {lid}")
-            layers.append(lyr)
-        root.setHasCustomLayerOrder(True)
-        root.setCustomLayerOrder(layers)
+            node = root.findLayer(lid)
+            if node is None:
+                raise Exception(f"Layer not found in layer tree: {lid}")
+            nodes.append(node)
+        parent = nodes[0].parent()
+        for node in nodes[1:]:
+            if node.parent() is not parent:
+                raise Exception("All layers must be in the same group to reorder")
+
+        siblings = list(parent.children())
+        slots = sorted(siblings.index(n) for n in nodes)
+        new_order = list(siblings)
+        for slot, node in zip(slots, nodes):
+            new_order[slot] = node
+        clones = [n.clone() for n in new_order]
+        parent.insertChildNodes(0, clones)
+        for node in siblings:
+            parent.removeChildNode(node)
+
+        root.setHasCustomLayerOrder(False)
         return {"ok": True, "order": layer_ids}
 
     # ------------------------------------------------------------------

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -2034,8 +2034,10 @@ async def duplicate_layer(
 @mcp.tool(
     title="Set Layer Order",
     annotations=ToolAnnotations(idempotentHint=True),
-    description="Set the explicit layer draw order in the tree. layer_ids is the ordered list "
-    "of layer ids from top (drawn last) to bottom.",
+    description="Reorder layer tree nodes; tree order is draw order. layer_ids is the ordered "
+    "list of layer ids from top (drawn last) to bottom; unlisted layers keep their slots. "
+    "Clears any custom draw order (it freezes a snapshot list — layers added later would "
+    "silently draw behind everything).",
 )
 async def set_layer_order(ctx: Context, layer_ids: list[str]) -> dict:
     return await _send("set_layer_order", {"layer_ids": layer_ids})


### PR DESCRIPTION
> **⚠️ Note: this change was authored by an AI (Claude, via Claude Code) and reviewed by @Gunther-Schulz.**

## Problem

`set_layer_order` calls `root.setHasCustomLayerOrder(True)` + `root.setCustomLayerOrder(layers)`. QGIS's custom layer order is a **frozen snapshot** list: any layer added *after* this call is absent from the snapshot and silently draws behind everything already in it. In practice a freshly added layer (e.g. a digitised shapefile) disappears under a WMS basemap, with no error and no obvious cause.

## Fix

Reorder the **layer-tree nodes** directly (tree order = draw order) and clear any custom order. Listed layers are rearranged within their common parent; unlisted siblings keep their slots. Because there's no frozen snapshot, layers added later render in their correct tree position.

## Tests

Existing `test_set_layer_order_tool` passes; full suite green (115 passed).
