### PR TITLE
refactor: extract protocol.py so the socket client imports without the mcp package

### DIFF
--- a/src/qgis_mcp/client.py
+++ b/src/qgis_mcp/client.py
@@ -10,7 +10,7 @@ import json
 import logging
 import socket
 
-from qgis_mcp.helpers import (
+from qgis_mcp.protocol import (
     DEFAULT_HOST,
     DEFAULT_PORT,
     HEADER_STRUCT,

--- a/src/qgis_mcp/helpers.py
+++ b/src/qgis_mcp/helpers.py
@@ -1,48 +1,27 @@
 """Shared helpers for server.py and compound_tools.py.
 
-Imports only from ``mcp`` and stdlib — no circular-import risk.
+Imports only from ``mcp``, stdlib, and the stdlib-only ``protocol``
+module — no circular-import risk. Protocol constants live in
+``protocol.py`` (and are re-exported here) so the client stays
+importable without the ``mcp`` package.
 """
 
 import importlib.metadata
 import json
-import os
-import struct
 
 from mcp.types import Annotations, ImageContent, ResourceLink, TextContent
 
-# ---------------------------------------------------------------------------
-# Protocol constants — single source of truth for defaults across all modules
-# ---------------------------------------------------------------------------
-
-DEFAULT_HOST = "localhost"
-DEFAULT_PORT = 9876
-TIMEOUT_DEFAULT = 30  # seconds — most tool commands
-TIMEOUT_LONG = 60  # seconds — execute_processing, render_map, execute_code, batch
-RECV_CHUNK_SIZE = 65536  # bytes per recv/recv_into call
-MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB — plugin-side buffer/message limit
-HEADER_STRUCT = struct.Struct(">I")  # 4-byte big-endian uint32 length prefix
-
-BATCH_BLOCKED_COMMANDS = frozenset(
-    {
-        "execute_code",
-        "remove_layer",
-        "delete_features",
-        "set_setting",
-        "reload_plugin",
-    }
+from qgis_mcp.protocol import (  # noqa: F401 — re-exported for server-side importers
+    BATCH_BLOCKED_COMMANDS,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    HEADER_STRUCT,
+    MAX_MESSAGE_SIZE,
+    RECV_CHUNK_SIZE,
+    TIMEOUT_DEFAULT,
+    TIMEOUT_LONG,
+    get_auth_token,
 )
-
-
-def get_auth_token():
-    """Return the shared-secret socket token, or ``None`` when auth is disabled.
-
-    Read from the ``QGIS_MCP_TOKEN`` environment variable. When unset or empty,
-    authentication is off and behaviour is unchanged — the plugin accepts any
-    command (the historical default). When set, the client attaches it to every
-    command and the plugin rejects commands that don't present a matching token.
-    """
-    token = os.environ.get("QGIS_MCP_TOKEN", "").strip()
-    return token or None
 
 
 def enrich_diagnose(result: dict) -> dict:

--- a/src/qgis_mcp/protocol.py
+++ b/src/qgis_mcp/protocol.py
@@ -1,0 +1,43 @@
+"""Wire-protocol constants and auth shared by client and server.
+
+Stdlib-only — the client must stay importable in environments without the
+``mcp`` package (e.g. gis_utils' qgis_bridge connecting from a plain
+conda env).
+"""
+
+import os
+import struct
+
+# ---------------------------------------------------------------------------
+# Protocol constants — single source of truth for defaults across all modules
+# ---------------------------------------------------------------------------
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 9876
+TIMEOUT_DEFAULT = 30  # seconds — most tool commands
+TIMEOUT_LONG = 60  # seconds — execute_processing, render_map, execute_code, batch
+RECV_CHUNK_SIZE = 65536  # bytes per recv/recv_into call
+MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB — plugin-side buffer/message limit
+HEADER_STRUCT = struct.Struct(">I")  # 4-byte big-endian uint32 length prefix
+
+BATCH_BLOCKED_COMMANDS = frozenset(
+    {
+        "execute_code",
+        "remove_layer",
+        "delete_features",
+        "set_setting",
+        "reload_plugin",
+    }
+)
+
+
+def get_auth_token():
+    """Return the shared-secret socket token, or ``None`` when auth is disabled.
+
+    Read from the ``QGIS_MCP_TOKEN`` environment variable. When unset or empty,
+    authentication is off and behaviour is unchanged — the plugin accepts any
+    command (the historical default). When set, the client attaches it to every
+    command and the plugin rejects commands that don't present a matching token.
+    """
+    token = os.environ.get("QGIS_MCP_TOKEN", "").strip()
+    return token or None


### PR DESCRIPTION
> **⚠️ Note: this change was authored by an AI (Claude, via Claude Code) and reviewed by @Gunther-Schulz.**

## Problem

Wire-protocol constants (host/port, timeouts, framing) and `get_auth_token` live in `helpers.py`, which does `from mcp.types import …`. That makes `qgis_mcp.client` unimportable in any environment without the `mcp` package installed — e.g. a downstream tool that only wants the lightweight socket client, not the full MCP server stack.

## Change

Move the stdlib-only constants + auth into a new `src/qgis_mcp/protocol.py`. `client.py` imports from `protocol`; `helpers.py` re-exports them so server-side callers are unaffected. Pure refactor, **no behaviour change**.

## Tests

Full suite green (115 passed); `qgis_mcp.client` now imports in an environment without `mcp`.
