### PR TITLE
feat(install): add opencode + Hermes (Windows) agent integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,99 @@ Add to `opencode.json` at your project root:
 </details>
 
 <details>
+<summary>Hermes desktop app (Windows)</summary>
+
+Hermes stores MCP servers in `config.yaml` under an `mcpServers` block. A standalone `mcp.json` is **ignored**. You also need a small `.bat` launcher — running `uvx` directly inside Hermes causes a venv conflict (`ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'`).
+
+**Step 1 — Create `%APPDATA%\Hermes\qgis-mcp-launch.bat`:**
+
+```batch
+@echo off
+REM Clears Hermes's venv vars so uvx uses a clean Python environment.
+set VIRTUAL_ENV=
+set PYTHONPATH=
+set PYTHONHOME=
+uvx --from "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip" qgis-mcp-server
+```
+
+**Step 2 — Add to `%APPDATA%\Hermes\config.yaml`:**
+
+```yaml
+mcpServers:
+  qgis:
+    command: "C:\\Users\\<you>\\AppData\\Roaming\\Hermes\\qgis-mcp-launch.bat"
+    args: []
+```
+
+Replace `<you>` with your Windows username. Restart Hermes, then verify with:
+```
+Call the QGIS ping tool.
+```
+
+> **Tip:** The QGIS plugin's **Setup & Configurator** dialog has a **hermes** entry in the
+> client dropdown. Select it and click **Copy** to get the bat file and YAML pre-filled
+> with your local paths.
+
+For the full guide see [`docs/agent-integration.md`](docs/agent-integration.md).
+
+</details>
+
+<details>
+<summary>Nous / Hermes-style agents and other MCP-compatible clients (opencode, …)</summary>
+
+**opencode** (which runs Nous/Hermes and other models) is supported directly by the installer:
+
+```bash
+python install.py --non-interactive --clients opencode
+```
+
+This writes the correct config block to `~/.config/opencode/config.json`
+(`%APPDATA%\opencode\config.json` on Windows).
+
+To configure manually, add to your `opencode.json` or global opencode config:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "qgis": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "--from", "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip",
+        "qgis-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+Any other agent or client that supports the MCP stdio transport can also use this server.
+Generic config (exact key names vary by client — see your agent's docs):
+
+```json
+{
+  "mcpServers": {
+    "qgis": {
+      "command": "uvx",
+      "args": [
+        "--from", "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip",
+        "qgis-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+After starting the agent, verify by asking it to call the `ping` tool — it
+should return `{"pong": true}` when the QGIS plugin is running.
+
+For a full setup guide, troubleshooting steps, and compound-tool mode configuration see
+[`docs/agent-integration.md`](docs/agent-integration.md).
+
+</details>
+
+<details>
 <summary>Claude Desktop, Cursor, VS Code, Windsurf, and others</summary>
 
 Add to your client's MCP config file:

--- a/docs/agent-integration.md
+++ b/docs/agent-integration.md
@@ -1,0 +1,275 @@
+# Using QGIS MCP with Agent Clients
+
+QGIS MCP uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) over **stdio**
+transport, which makes it compatible with any MCP-capable agent framework — not just Claude.
+This guide covers how to register the server in various agent environments, including
+Nous/Hermes-style coding agents that support MCP tool-use.
+
+## How it works
+
+```
+Agent (LLM) ←→ MCP Client ←→ stdio ←→ qgis-mcp-server ←→ TCP socket ←→ QGIS Plugin
+```
+
+The MCP server is a plain Python process launched by the agent's MCP client.  No special
+Nous-specific API is involved — any agent that can spawn an MCP stdio server and call tools
+can use QGIS MCP.
+
+---
+
+## Prerequisites
+
+1. **QGIS 3.28+** installed with the **QGIS MCP plugin** enabled:
+   - `Plugins` › `Manage and Install Plugins` › search **QGIS MCP** › Install.
+   - Restart QGIS, then open the QGIS MCP dock widget and click **Start Server**.
+   - The plugin listens on `localhost:9876` by default.
+
+2. **[uv](https://docs.astral.sh/uv/getting-started/installation/)** — the Python package
+   runner used to launch the MCP server without a manual `pip install`.
+
+---
+
+## MCP client configuration (generic)
+
+Any MCP-capable client that accepts a JSON or TOML config block can use this snippet:
+
+```json
+{
+  "mcpServers": {
+    "qgis": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip",
+        "qgis-mcp-server"
+      ]
+    }
+  }
+}
+```
+
+Or, if you have a local clone of this repository:
+
+```json
+{
+  "mcpServers": {
+    "qgis": {
+      "command": "uv",
+      "args": ["--directory", "/path/to/qgis-mcp", "run", "--no-sync", "src/qgis_mcp/server.py"]
+    }
+  }
+}
+```
+
+### With optional environment variables
+
+```json
+{
+  "mcpServers": {
+    "qgis": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip",
+        "qgis-mcp-server"
+      ],
+      "env": {
+        "QGIS_MCP_HOST": "localhost",
+        "QGIS_MCP_PORT": "9876",
+        "QGIS_MCP_TOKEN": "your-long-random-secret"
+      }
+    }
+  }
+}
+```
+
+---
+
+## Nous / Hermes-style agents
+
+The [Nous Research portal](https://portal.nousresearch.com/) and Hermes-based agents that
+support MCP tool-use can connect to QGIS MCP just like any other MCP client.
+
+### Step 1 — Identify how your agent loads MCP servers
+
+Nous/Hermes agents that support the MCP tool-calling interface typically accept a server
+configuration in one of these forms:
+
+- A JSON config file (often `mcp.json`, `mcp_servers.json`, or `opencode.json`).
+- A CLI flag such as `--mcp-server "command args"`.
+- An environment variable or API payload listing server configs.
+
+Consult your specific agent client's documentation for the exact format, then paste in the
+generic JSON block above.
+
+### Step 2 — Verify tool discovery
+
+Once the agent starts the MCP server, it should list the available tools.  You can verify
+by asking the agent:
+
+```
+List the available MCP tools for QGIS.
+```
+
+You should see 103 tools (e.g. `ping`, `get_layers`, `render_map`, …).
+
+### Step 3 — Check the connection
+
+Ask the agent to call the `ping` tool:
+
+```
+Call the QGIS ping tool to verify the connection.
+```
+
+If QGIS is running with the plugin started you will get `{"pong": true}`.
+
+---
+
+## Hermes desktop app (Windows)
+
+This section documents a verified-working local setup: QGIS on the same Windows machine
+as the **Hermes desktop app**, controlled through the QGIS MCP plugin — no remote box
+required.
+
+### Prerequisites
+
+- QGIS installed (OSGeo4W build at `C:\OSGeo4W` or standalone `C:\Program Files\QGIS 3.xx`).
+- The QGIS MCP plugin installed and enabled inside QGIS
+  (`Plugins` › `Manage and Install Plugins` › **QGIS MCP**).
+- Hermes desktop app running locally, with `uvx` available on `PATH`.
+
+### Why a launcher .bat is required
+
+Hermes ships with its own Python venv.  If you register `uvx` directly in Hermes's
+`config.yaml`, Hermes inherits its own `VIRTUAL_ENV` / `PYTHONPATH` values when it spawns
+the MCP server process.  The `qgis-mcp-server` then imports Hermes's (incompatible) copies
+of `mcp` and `pydantic`, causing:
+
+```
+ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'
+```
+
+The fix is a small `.bat` file that clears the venv environment variables before calling
+`uvx`, so the MCP server runs in a clean environment.
+
+### Step 1 — Create the launcher bat file
+
+Create `qgis-mcp-launch.bat` in your Hermes config directory
+(typically `%APPDATA%\Hermes\`):
+
+```batch
+@echo off
+REM Launch qgis-mcp-server isolated from Hermes's own Python venv.
+REM Clearing venv vars prevents Hermes's pydantic/mcp from being imported.
+set VIRTUAL_ENV=
+set PYTHONPATH=
+set PYTHONHOME=
+uvx --from "https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip" qgis-mcp-server
+```
+
+Full path example:
+```
+C:\Users\<you>\AppData\Roaming\Hermes\qgis-mcp-launch.bat
+```
+
+### Step 2 — Register the server in config.yaml
+
+Hermes stores MCP servers in `config.yaml` (not a separate `mcp.json`).  Open
+`%APPDATA%\Hermes\config.yaml` and add the `mcpServers` block — or merge it in if the file
+already exists:
+
+```yaml
+mcpServers:
+  qgis:
+    command: "C:\\Users\\<you>\\AppData\\Roaming\\Hermes\\qgis-mcp-launch.bat"
+    args: []
+```
+
+Replace `<you>` with your actual Windows username.
+
+### Step 3 — Verify
+
+1. Restart Hermes after editing `config.yaml`.
+2. Ask Hermes to call the `ping` tool:
+   ```
+   Call the QGIS ping tool.
+   ```
+3. You should get `{"pong": true}` when the QGIS plugin server is running.
+
+### Quick setup via the QGIS plugin configurator
+
+The QGIS MCP plugin's **Setup & Configurator** dialog (Plugins › QGIS MCP › MCP Setup
+Configurator) has a **hermes** entry in the client dropdown.  Select it and click **Copy**
+to get the full bat-file content and YAML snippet pre-filled with your local paths.
+
+---
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `QGIS_MCP_HOST` | `localhost` | Host where the QGIS plugin socket listens |
+| `QGIS_MCP_PORT` | `9876` | Port for the QGIS plugin socket |
+| `QGIS_MCP_TOKEN` | _(unset)_ | Optional shared secret for socket auth |
+| `QGIS_MCP_TRANSPORT` | `stdio` | MCP transport: `stdio` or `streamable-http` |
+| `QGIS_MCP_LOG_FILE` | `~/.local/share/qgis-mcp/server.log` | Log file path (empty to disable) |
+| `QGIS_MCP_LOG_LEVEL` | `INFO` | File log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `QGIS_MCP_TOOL_MODE` | `granular` | `granular` (103 tools) or `compound` (~23 grouped tools) |
+
+---
+
+## Troubleshooting
+
+### "No response from QGIS" / connection refused
+
+- Confirm QGIS is open and the QGIS MCP dock widget shows **Server running**.
+- Check the port: the plugin defaults to `9876`.  Override with `QGIS_MCP_PORT` if you
+  changed it in the plugin settings.
+- On macOS/Linux run `ss -tlnp | grep 9876` (or `netstat -an | grep 9876`) to confirm the
+  port is listening.
+
+### Tools not appearing / empty tool list
+
+- Make sure the MCP server process started successfully.  Run it manually to check:
+  ```bash
+  uvx --from https://github.com/nkarasiak/qgis-mcp/archive/refs/heads/main.zip qgis-mcp-server
+  ```
+  It should print nothing and wait (reading MCP messages from stdin). `Ctrl-C` to quit.
+- If you see `ModuleNotFoundError`, `uv`/`uvx` is not installed or not on `PATH`.
+- If you see `Connection refused`, the QGIS plugin is not listening yet — start it first.
+
+### Agent says "tool call failed" for every command
+
+- The MCP server started but can't reach QGIS.  Confirm the plugin is running (see above).
+- If you set `QGIS_MCP_TOKEN`, make sure the **same** token is in the MCP server's `env`
+  block in your config.
+
+### Streamable-HTTP transport (remote / multi-client)
+
+If the agent cannot spawn subprocesses but can make HTTP requests, set
+`QGIS_MCP_TRANSPORT=streamable-http` in the server environment and point the client at
+`http://localhost:8000/mcp/` (default FastMCP HTTP endpoint).
+
+---
+
+## Compound tool mode
+
+If your agent has a limited context window or struggles with 103 separate tool schemas,
+enable compound tool mode to reduce the tool count to 23 grouped tools:
+
+```json
+{
+  "mcpServers": {
+    "qgis": {
+      "command": "uvx",
+      "args": ["--from", "...", "qgis-mcp-server"],
+      "env": { "QGIS_MCP_TOOL_MODE": "compound" }
+    }
+  }
+}
+```
+
+Each compound tool takes an `action` parameter to select the operation.  The groups are:
+`system`, `project`, `layer`, `features`, `selection`, `style`, `canvas`, `render`,
+`processing`, `code`, `batch`, `layer_tree`, `plugins`, `variables`, `settings`,
+`expression`, `transform`, `message_log`, `layer_property`.

--- a/install.py
+++ b/install.py
@@ -2,10 +2,11 @@
 """Multi-client installer for QGIS MCP.
 
 Symlinks the QGIS plugin and configures MCP clients (Claude Desktop,
-Cursor, VS Code Copilot, Windsurf, Zed, Claude Code, Codex CLI).
+Cursor, VS Code Copilot, Windsurf, Zed, Claude Code, Codex CLI, opencode).
 
 Usage:
     python install.py                          # Interactive menu
+    python install.py --non-interactive --clients opencode
     python install.py --non-interactive --clients claude-desktop,cursor
     python install.py --remote                 # Use uvx (no local clone needed)
     python install.py --uninstall --clients cursor
@@ -16,10 +17,10 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
-import re
 from pathlib import Path
 
 REPO_DIR = Path(__file__).resolve().parent
@@ -97,6 +98,16 @@ def _client_registry() -> dict[str, ClientInfo]:
     else:
         zed_cfg = home / ".config" / "zed" / "settings.json"
 
+    # opencode (https://opencode.ai) - uses "mcp" key with type/command-array format
+    if sys.platform == "win32":
+        opencode_cfg = appdata / "opencode" / "config.json"
+    else:
+        opencode_cfg = home / ".config" / "opencode" / "config.json"
+
+    # Hermes desktop app (Windows) - uses config.yaml with mcpServers block.
+    # Requires a .bat launcher to avoid Hermes's venv polluting the MCP server.
+    hermes_cfg = appdata / "Hermes" / "config.yaml" if sys.platform == "win32" else None
+
     return {
         "claude-desktop": {"path": claude_cfg, "key": "mcpServers"},
         "cursor": {"path": cursor_cfg, "key": "mcpServers"},
@@ -105,6 +116,8 @@ def _client_registry() -> dict[str, ClientInfo]:
         "zed": {"path": zed_cfg, "key": "context_servers"},
         "claude-code": {"print_only": True, "cli": "claude"},
         "codex": {"print_only": True, "cli": "codex"},
+        "opencode": {"path": opencode_cfg, "key": "mcp", "entry_format": "opencode"},
+        "hermes": {"print_only": True, "entry_format": "hermes", "hermes_cfg": hermes_cfg},
     }
 
 
@@ -184,6 +197,86 @@ def _remote_entry() -> dict:
 
 def _server_entry(client: str, remote: bool) -> dict:
     return _remote_entry() if remote else _local_entry()
+
+
+def _opencode_server_entry(remote: bool) -> dict:
+    """Build an MCP server entry in opencode's native format.
+
+    opencode uses ``{"type": "local", "command": [...]}`` (command as an array)
+    under the top-level ``"mcp"`` key instead of the ``mcpServers`` / split
+    command+args shape used by most other clients.
+    """
+    if remote:
+        cmd: list[str] = ["uvx", "--from", GITHUB_URL, "qgis-mcp-server"]
+    elif shutil.which("uv"):
+        cmd = [
+            "uv",
+            "--directory",
+            str(REPO_DIR),
+            "run",
+            "--no-sync",
+            "src/qgis_mcp/server.py",
+        ]
+    else:
+        cmd = [str(_venv_python()), str(REPO_DIR / "src" / "qgis_mcp" / "server.py")]
+    return {"type": "local", "command": cmd}
+
+
+def _hermes_bat_content(remote: bool) -> str:
+    """Return the content of qgis-mcp-launch.bat for Hermes desktop app (Windows).
+
+    The .bat clears the Python venv environment set by Hermes before launching
+    uvx, preventing Hermes's broken pydantic/mcp packages from being imported
+    by the qgis-mcp-server process.
+    """
+    if remote:
+        launch_cmd = f'uvx --from "{GITHUB_URL}" qgis-mcp-server'
+    elif shutil.which("uv"):
+        launch_cmd = (
+            f'uv --directory "{REPO_DIR}" run --no-sync src/qgis_mcp/server.py'
+        )
+    else:
+        python = _venv_python()
+        launch_cmd = f'"{python}" "{REPO_DIR / "src" / "qgis_mcp" / "server.py"}"'
+    return (
+        # CRLF line endings are intentional: .bat files must use Windows line endings
+        # to work correctly regardless of the text editor used to create them.
+        "@echo off\r\n"
+        "REM Launcher for qgis-mcp-server, isolated from Hermes's own Python venv.\r\n"
+        "REM Clears venv vars so uvx/uv uses the system Python, not Hermes's packages.\r\n"
+        "set VIRTUAL_ENV=\r\n"
+        "set PYTHONPATH=\r\n"
+        "set PYTHONHOME=\r\n"
+        f"{launch_cmd}\r\n"
+    )
+
+
+def _hermes_instructions(remote: bool) -> None:
+    """Print step-by-step Hermes desktop app setup instructions (Windows only)."""
+    home = _home()
+    hermes_dir = Path(os.environ.get("APPDATA", home / "AppData" / "Roaming")) / "Hermes"
+    bat_path = hermes_dir / "qgis-mcp-launch.bat"
+    cfg_path = hermes_dir / "config.yaml"
+
+    bat_content = _hermes_bat_content(remote)
+
+    print()
+    print("  Hermes desktop app (Windows) — manual setup required:")
+    print()
+    print(f"  Step 1 — Create the launcher: {bat_path}")
+    print()
+    for line in bat_content.splitlines():
+        print(f"    {line}")
+    print()
+    print(f"  Step 2 — Add to {cfg_path}:")
+    print()
+    bat_escaped = str(bat_path).replace("\\", "\\\\")
+    print("    mcpServers:")
+    print("      qgis:")
+    print(f'        command: "{bat_escaped}"')
+    print("        args: []")
+    print()
+    print("  See docs/agent-integration.md for full details.")
 
 
 # ── Plugin installation ────────────────────────────────────────────────────
@@ -302,6 +395,11 @@ def configure_client(client_name: str, remote: bool) -> None:
     registry = _client_registry()
     info = registry[client_name]
 
+    # Hermes desktop app: YAML config + bat launcher — print instructions only
+    if info.get("entry_format") == "hermes":
+        _hermes_instructions(remote)
+        return
+
     # CLI-based clients (Claude Code, Codex): use their `mcp add` subcommand
     if info.get("print_only"):
         cli_name = info.get("cli", "claude")
@@ -354,7 +452,10 @@ def configure_client(client_name: str, remote: bool) -> None:
 
     path = Path(info["path"])
     key = info["key"]
-    entry = _server_entry(client_name, remote)
+    if info.get("entry_format") == "opencode":
+        entry = _opencode_server_entry(remote)
+    else:
+        entry = _server_entry(client_name, remote)
 
     config = _read_json(path)
     if path.exists():
@@ -369,6 +470,13 @@ def configure_client(client_name: str, remote: bool) -> None:
 def unconfigure_client(client_name: str) -> None:
     registry = _client_registry()
     info = registry[client_name]
+
+    # Hermes: manual YAML edit required — just advise the user
+    if info.get("entry_format") == "hermes":
+        hermes_cfg = info.get("hermes_cfg")
+        cfg_hint = str(hermes_cfg) if hermes_cfg else "%APPDATA%\\Hermes\\config.yaml"
+        print(f"  Hermes: remove the 'qgis' key from mcpServers in {cfg_hint} manually.")
+        return
 
     if info.get("print_only"):
         cli_name = info.get("cli", "claude")
@@ -408,7 +516,7 @@ def unconfigure_client(client_name: str) -> None:
 
 # ── Interactive menu ────────────────────────────────────────────────────────
 
-ALL_CLIENTS = ["claude-desktop", "cursor", "vscode", "windsurf", "zed", "claude-code", "codex"]
+ALL_CLIENTS = ["claude-desktop", "cursor", "vscode", "windsurf", "zed", "claude-code", "codex", "opencode", "hermes"]
 
 
 def interactive_menu() -> list[str]:

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -3320,6 +3320,13 @@ def _client_config_registry(repo_dir):
 
     opencode_cfg = home / ".config" / "opencode" / "opencode.json"
 
+    # Hermes desktop app (Windows) - YAML-based config, handled as print_only
+    hermes_cfg = (
+        appdata / "Hermes" / "config.yaml"
+        if sys.platform == "win32" and appdata
+        else None
+    )
+
     return {
         "claude-desktop": {"path": claude_cfg, "key": "mcpServers"},
         "cursor": {"path": cursor_cfg, "key": "mcpServers"},
@@ -3328,6 +3335,7 @@ def _client_config_registry(repo_dir):
         "zed": {"path": zed_cfg, "key": "context_servers"},
         "opencode": {"path": opencode_cfg, "key": "mcp"},
         "claude-code": {"print_only": True},
+        "hermes": {"print_only": True, "entry_format": "hermes", "hermes_cfg": hermes_cfg},
     }
 
 
@@ -3429,7 +3437,7 @@ class MCPConfiguratorDialog(QDialog):
         client_row.addWidget(QLabel("Client:"))
         self.client_combo = QComboBox()
         self.client_combo.addItems(
-            ["claude-code", "claude-desktop", "cursor", "opencode", "vscode", "windsurf", "zed"]
+            ["claude-code", "claude-desktop", "cursor", "hermes", "opencode", "vscode", "windsurf", "zed"]
         )
         self.client_combo.setMinimumWidth(180)
         self.client_combo.currentTextChanged.connect(self._on_client_changed)
@@ -3595,6 +3603,55 @@ class MCPConfiguratorDialog(QDialog):
             }
         return entry
 
+    def _hermes_preview_text(self, remote: bool) -> str:
+        """Return the full setup instructions for Hermes desktop app (Windows).
+
+        Note: the bat-file content here mirrors install.py's _hermes_bat_content().
+        The plugin cannot import install.py (it runs inside QGIS), so the logic is
+        intentionally duplicated to keep the plugin self-contained.
+        """
+        home = Path.home()
+        appdata = Path(os.environ.get("APPDATA", str(home / "AppData" / "Roaming")))
+        hermes_dir = appdata / "Hermes"
+        bat_path = hermes_dir / "qgis-mcp-launch.bat"
+        cfg_path = hermes_dir / "config.yaml"
+
+        if remote:
+            launch_cmd = f'uvx --from "{self.github_url}" qgis-mcp-server'
+        else:
+            uv = self._find_uv() or "uv"
+            launch_cmd = f'"{uv}" --directory "{self.repo_dir}" run --no-sync src/qgis_mcp/server.py'
+
+        bat_lines = [
+            "@echo off",
+            "REM Launch qgis-mcp-server isolated from Hermes's own Python venv.",
+            "REM Clearing venv vars prevents Hermes's pydantic/mcp from being imported.",
+            "set VIRTUAL_ENV=",
+            "set PYTHONPATH=",
+            "set PYTHONHOME=",
+            launch_cmd,
+        ]
+        bat_content = "\n".join(bat_lines)
+
+        bat_escaped = str(bat_path).replace("\\", "\\\\")
+        yaml_block = (
+            "mcpServers:\n"
+            "  qgis:\n"
+            f'    command: "{bat_escaped}"\n'
+            "    args: []"
+        )
+
+        return (
+            f"Step 1 — Create this file:\n"
+            f"  {bat_path}\n\n"
+            f"Contents:\n"
+            f"{bat_content}\n\n"
+            f"Step 2 — Add to:\n"
+            f"  {cfg_path}\n\n"
+            f"{yaml_block}\n\n"
+            f"See docs/agent-integration.md for full details."
+        )
+
     def update_preview(self):
         client = self.client_combo.currentText()
         remote = self.mode_combo.currentText().startswith("Remote")
@@ -3602,6 +3659,13 @@ class MCPConfiguratorDialog(QDialog):
         # Refresh only applies to remote (uvx) mode.
         self.refresh_check.setEnabled(remote)
         info = self._get_client_info(client)
+
+        if info.get("entry_format") == "hermes":
+            self.preview_label.setText(
+                "Manual setup required — copy the .bat content and YAML config below:"
+            )
+            self.preview_edit.setPlainText(self._hermes_preview_text(remote))
+            return
 
         if info.get("print_only"):
             if remote:
@@ -3624,6 +3688,23 @@ class MCPConfiguratorDialog(QDialog):
     def refresh_status(self):
         client = self.client_combo.currentText()
         info = self._get_client_info(client)
+
+        if info.get("entry_format") == "hermes":
+            hermes_cfg = info.get("hermes_cfg")
+            if hermes_cfg and hermes_cfg.exists():
+                self.status_label.setText(
+                    f"Status: config.yaml found — verify 'qgis' is in mcpServers ({hermes_cfg})"
+                )
+                self.status_label.setStyleSheet("color: orange;")
+            else:
+                cfg_hint = str(hermes_cfg) if hermes_cfg else "%APPDATA%\\Hermes\\config.yaml"
+                self.status_label.setText(
+                    f"Status: Follow the steps below, then edit {cfg_hint}"
+                )
+                self.status_label.setStyleSheet("color: gray;")
+            self.apply_btn.setEnabled(False)
+            self.update_preview()
+            return
 
         if info.get("print_only"):
             self.status_label.setText("Run the command above in your terminal.")

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1912,6 +1912,50 @@ def test_compound_tools_register():
     assert mock_mcp.tool.call_count >= 14
 
 
+# --- MCP server tool-discovery (no QGIS required) ---
+
+
+@pytest.mark.asyncio
+async def test_server_advertises_tools():
+    """MCP server must expose a non-empty tool list to any MCP client.
+
+    This validates generic MCP interoperability: the server module correctly
+    registers all tools via FastMCP so that agents (Claude Code, Codex CLI,
+    Nous/Hermes-style clients, etc.) can discover them without a live QGIS
+    connection.
+    """
+    from qgis_mcp.server import mcp
+
+    tools = await mcp.list_tools()
+    tool_names = [t.name for t in tools]
+
+    # Core tools that every MCP client depends on for basic interoperability
+    assert "ping" in tool_names, "ping tool missing — clients use it to verify connectivity"
+    assert "get_layers" in tool_names, "get_layers tool missing"
+    assert "render_map" in tool_names, "render_map tool missing"
+
+    # Sanity-check that the full tool suite is registered (not just a stub).
+    # The server currently exposes 103 granular tools; allow some headroom for
+    # future additions/removals while still catching gross omissions.
+    assert len(tools) >= 100, f"Expected at least 100 tools, got {len(tools)}"
+
+
+@pytest.mark.asyncio
+async def test_server_tool_schemas_are_valid():
+    """Every registered tool must have a non-empty name and description.
+
+    Generic MCP clients (including Nous/Hermes agents) rely on tool metadata
+    to build system prompts and tool-call payloads — missing descriptions
+    degrade agent reasoning quality.
+    """
+    from qgis_mcp.server import mcp
+
+    tools = await mcp.list_tools()
+    for tool in tools:
+        assert tool.name, f"Tool has empty name: {tool!r}"
+        assert tool.description, f"Tool '{tool.name}' has no description"
+
+
 # --- Optional shared-secret auth (QGIS_MCP_TOKEN) ---
 
 


### PR DESCRIPTION
Brings PR #22 (from @GetBack2Basics's fork) into `dev`, cleaned for upstream.

## What
- **opencode** installer client — native `mcp` key, command-array format (`_opencode_server_entry`).
- **Hermes desktop app (Windows)** — generated `.bat` launcher clears Hermes's venv vars (`VIRTUAL_ENV`/`PYTHONPATH`/`PYTHONHOME`) before invoking uvx, avoiding the `pydantic_core._pydantic_core` import clash. `print_only` client + plugin Setup & Configurator `hermes` entry with live preview.
- **docs/agent-integration.md** — generic MCP-client + Nous/Hermes setup guide.
- **2 tests** — QGIS-free tool-discovery checks (`list_tools` non-empty, valid schemas).

## Cleanup vs original PR
- Removed fork "Fork of… / Antigravity" README banner.
- Rewrote all `GetBack2Basics/qgis-mcp` zip URLs → `nkarasiak/qgis-mcp`.
- Re-applied via 3-way patch onto current `dev` so recent plugin commits (runtime enum resolution, etc.) are preserved.

## Verification
- `pytest tests/test_mcp_tools.py` → 117 passed.
- `ruff check` clean. (Pre-existing flake8 E302 on `_read_json` left untouched — not introduced here.)

## Not addressed (minor doc drift, per request)
- docs say "103 tools" vs README's 102; compound group list shows 19 but text says 23.

Credit: original work by @GetBack2Basics (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)