### PR TITLE
fix: handle non-spatial tables in get_layers and get_project_info

### DIFF
--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -694,13 +694,21 @@ class QgisMCPServer(QObject):
                 "id": layer.id(),
                 "name": layer.name(),
                 "type": self._get_layer_type(layer),
-                "visible": (
-                    layer.isValid() and project.layerTreeRoot().findLayer(layer.id()).isVisible()
-                ),
+                "visible": layer.isValid() and self._is_visible(project, layer.id()),
             }
             info["layers"].append(layer_info)
 
         return info
+
+    def _is_visible(self, project, layer_id):
+        """Visibility of a layer in the layer tree.
+
+        Non-spatial tables (attribute-only tables, e.g. GeoPackage tables used by QGIS relations)
+        live in the project but have no node in the layer tree, so findLayer() returns None.
+        Treat them as not visible instead of raising AttributeError.
+        """
+        node = project.layerTreeRoot().findLayer(layer_id)
+        return node.isVisible() if node is not None else False
 
     def _get_layer_type(self, layer):
         if layer.type() == LAYER_VECTOR:
@@ -827,7 +835,7 @@ class QgisMCPServer(QObject):
                 "id": layer_id,
                 "name": layer.name(),
                 "type": self._get_layer_type(layer),
-                "visible": project.layerTreeRoot().findLayer(layer_id).isVisible(),
+                "visible": self._is_visible(project, layer_id),
             }
 
             if layer.type() == LAYER_VECTOR:


### PR DESCRIPTION
Fixes #31.

`get_layers` and `get_project_info` raise `AttributeError: 'NoneType' object has no attribute 'isVisible'` on any project containing a **non-spatial table** (attribute-only, `QgsWkbTypes.NoGeometry`). One such table makes both tools unusable for the whole project, not just for that table.

### Cause

`QgsProject.mapLayers()` returns every registered layer, but non-spatial tables have **no node in the layer tree**, so `layerTreeRoot().findLayer(id)` returns `None`. Both call sites dereferenced it directly.

In `get_project_info` the existing `layer.isValid()` guard does not help: the layer is perfectly valid, it simply is not in the tree.

The other three `findLayer()` call sites in the file (`set_layer_visibility`, `move_layer_to_group`, and the group helper) already handle `None` explicitly, which is why this looks like an oversight rather than a design decision.

### Change

Adds `_is_visible(project, layer_id)` — "no node in the tree" means not visible — and uses it in both places. No behaviour change for spatial layers.

### How to reproduce

Any GeoPackage with a parent/child relation (1:N attribute tables used by QGIS relations and forms) triggers it. In our case a plugin creates two child tables for multi-owner records, so every project it generates hit the bug.

1. Load a spatial layer and an attribute-only table (Layer ▸ Create Layer ▸ New GeoPackage Layer, geometry type "No geometry") into a project.
2. Call `get_layers` or `get_project_info`.

Verified on QGIS 3.44.11 LTR / Windows 11, against a real project with two non-spatial child tables: both tools return normally and the tables are reported with `"visible": false`.
