### PR TITLE
Fix response truncation and two Python 3.9 breaks (verified on QGIS 3.42.1)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,15 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]           # assert is fine in tests
-"qgis_mcp_plugin/*" = ["UP038"]  # runs inside QGIS (Python 3.9 on QGIS 3.28) — `X | Y` in isinstance needs 3.10+
+# The plugin runs inside QGIS's bundled interpreter, which is still Python 3.9
+# on releases well past the 3.28 minimum (QGIS 3.42 ships 3.9). Both rules below
+# push code toward 3.10-only constructs that raise TypeError at runtime there —
+# and the suite runs on 3.12, so CI never catches it. Use the tuple form of
+# isinstance and wire.zip_strict() instead.
+"qgis_mcp_plugin/*" = [
+    "UP038",  # `X | Y` in isinstance needs 3.10+
+    "B905",   # `zip(strict=)` needs 3.10+
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -857,7 +857,10 @@ class QgisMCPServer(QObject):
         if qvariant.isNull():
             return None
         value = qvariant.value()
-        if isinstance(value, int | float | str | bool | type(None)):
+        # Tuple form, not `int | float | ...`: PEP 604 unions in isinstance need
+        # Python 3.10, and QGIS ships 3.9 well past 3.28 (3.42 still does). The
+        # union form raises TypeError there, which broke every feature read.
+        if isinstance(value, (int, float, str, bool, type(None))):
             return value
         elif hasattr(value, "toPyDate"):
             return value.toPyDate().isoformat()
@@ -873,7 +876,10 @@ class QgisMCPServer(QObject):
         """Convert a feature attribute value to a JSON-serializable type."""
         if isinstance(value, QVariant):
             return self._convert_to_python_type(value)
-        if isinstance(value, int | float | str | bool | type(None)):
+        # Tuple form, not `int | float | ...`: PEP 604 unions in isinstance need
+        # Python 3.10, and QGIS ships 3.9 well past 3.28 (3.42 still does). The
+        # union form raises TypeError there, which broke every feature read.
+        if isinstance(value, (int, float, str, bool, type(None))):
             return value
         try:
             return str(value)

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -10,9 +10,9 @@ import re
 import secrets
 import shutil
 import socket
-import struct
 import sys
 import tempfile
+import time
 import traceback
 from collections import deque
 from pathlib import Path
@@ -58,6 +58,7 @@ from qgis.core import (
     QgsMultiBandColorRenderer,
     QgsPointXY,
     QgsPrintLayout,
+    QgsProcessingFeedback,
     QgsProcessingModelAlgorithm,
     QgsProcessingModelChildAlgorithm,
     QgsProcessingModelChildParameterSource,
@@ -98,6 +99,7 @@ from qgis.core import (
 from qgis.PyQt.QtCore import (
     QBuffer,
     QByteArray,
+    QCoreApplication,
     QEventLoop,
     QObject,
     QPointF,
@@ -185,6 +187,15 @@ from .compat import (
     TOOLBUTTON_MENU_POPUP,
     WKB_NO_GEOMETRY,
 )
+from .wire import (
+    BATCH_BLOCKED_COMMANDS,
+    HEADER_STRUCT,
+    MAX_MESSAGE_SIZE,
+    RECV_CHUNK_SIZE,
+    OutboundBuffer,
+    OutboundOverflow,
+    frame,
+)
 
 _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 9876
@@ -194,9 +205,9 @@ _DEFAULT_PORT = 9876
 # means the same thing here — the spin box floor is 1024, so EACCES cannot be the
 # "privileged port" case.
 _ADDR_IN_USE = frozenset({errno.EADDRINUSE, errno.EACCES, 10048, 10013})
-_RECV_CHUNK_SIZE = 65536
-_MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB
-_HEADER_STRUCT = struct.Struct(">I")
+_RECV_CHUNK_SIZE = RECV_CHUNK_SIZE
+_MAX_MESSAGE_SIZE = MAX_MESSAGE_SIZE
+_HEADER_STRUCT = HEADER_STRUCT
 
 
 def _json_safe(value):
@@ -215,6 +226,53 @@ def _json_safe(value):
     return value
 
 
+class _ResponsiveFeedback(QgsProcessingFeedback):
+    """Processing feedback that keeps the GUI alive and enforces a deadline.
+
+    ``processing.run()`` is synchronous and, called straight from the server's
+    timer callback, blocks Qt's event loop for its whole duration — the QGIS
+    window freezes under the user's cursor, which defeats the point of driving a
+    live instance they can also touch. Pumping the event loop on each progress
+    report keeps the UI responsive and gives the algorithm a cancellation point.
+
+    Re-entrancy is safe: ``processEvents`` re-fires the server timer, but
+    ``_in_dispatch`` makes ``process_server`` return immediately, so no nested
+    command runs inside this one.
+
+    Caveat: algorithms that never report progress never reach these hooks, so
+    they can neither pump nor time out. Long raster work is better run with
+    GDAL outside the live instance.
+    """
+
+    # Pump at most this often; processEvents() on every progress tick of a fast
+    # algorithm costs more than the responsiveness it buys.
+    _PUMP_INTERVAL = 0.05  # seconds
+
+    def __init__(self, budget_seconds):
+        super().__init__()
+        self._deadline = time.monotonic() + budget_seconds
+        self._last_pump = 0.0
+        self.timed_out = False
+
+    def _tick(self):
+        now = time.monotonic()
+        if now >= self._deadline:
+            self.timed_out = True
+            self.cancel()
+            return
+        if now - self._last_pump >= self._PUMP_INTERVAL:
+            self._last_pump = now
+            QCoreApplication.processEvents()
+
+    def setProgress(self, progress):
+        self._tick()
+        super().setProgress(progress)
+
+    def pushInfo(self, info):
+        self._tick()
+        super().pushInfo(info)
+
+
 class QgisMCPServer(QObject):
     """Server class to handle socket connections and execute QGIS commands"""
 
@@ -230,9 +288,19 @@ class QgisMCPServer(QObject):
         self.running = False
         self.socket = None
         self.clients: dict[socket.socket, bytes] = {}
+        # Unsent response bytes per client. Sockets are non-blocking, so a large
+        # response may not fit the kernel buffer in one call; the remainder is
+        # queued here and drained on later timer ticks.
+        self.outbound: dict[socket.socket, OutboundBuffer] = {}
         self.timer = None
         self._message_log = deque(maxlen=1000)
         self.start_error = None  # why start() failed, for the UI to report
+        # Guards against re-entrant dispatch. Long handlers (render_map, and
+        # processing via its feedback hook) pump the Qt event loop so the GUI
+        # stays responsive, which re-fires this server's timer. Without the
+        # guard a second client's command could execute *inside* the first
+        # one's handler, interleaving edit sessions and project state.
+        self._in_dispatch = False
 
     def _notify_clients_changed(self):
         """Report the active client count to the UI (badge on the toolbar icon)."""
@@ -240,10 +308,31 @@ class QgisMCPServer(QObject):
             with contextlib.suppress(Exception):
                 self.on_clients_changed(len(self.clients))
 
+    _LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1", ""})
+
     def start(self):
         """Start the server"""
         self.running = True
         self.start_error = None
+
+        # Refuse to expose an unauthenticated execute_code endpoint beyond this
+        # machine. On loopback the token is advisory (a same-user process can
+        # read the environment anyway), but a non-loopback bind puts arbitrary
+        # PyQGIS execution on the network, where anyone who can route to the
+        # port gets it. That is not a default anyone should be able to reach by
+        # accident, so it requires an explicit token.
+        if str(self.host).lower() not in self._LOOPBACK_HOSTS and not os.environ.get(
+            "QGIS_MCP_TOKEN", ""
+        ).strip():
+            self.start_error = (
+                f"Refusing to bind {self.host}: a non-loopback address exposes "
+                "arbitrary code execution to the network. Set QGIS_MCP_TOKEN "
+                "(in QGIS and in the MCP server) to enable this, or bind localhost."
+            )
+            QgsMessageLog.logMessage(self.start_error, self.LOG_TAG, MSG_CRITICAL)
+            self.running = False
+            return False
+
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # SO_REUSEADDR does not mean the same thing on both platforms. On Windows
         # it lets a second socket bind a port another socket already holds, so two
@@ -316,6 +405,7 @@ class QgisMCPServer(QObject):
             with contextlib.suppress(Exception):
                 client_sock.close()
         self.clients.clear()
+        self.outbound.clear()
         self._notify_clients_changed()
 
         self.socket = None
@@ -326,21 +416,58 @@ class QgisMCPServer(QObject):
         with contextlib.suppress(Exception):
             client_sock.close()
         self.clients.pop(client_sock, None)
+        self.outbound.pop(client_sock, None)
         QgsMessageLog.logMessage(f"{message} ({len(self.clients)} active)", self.LOG_TAG, level)
         self._notify_clients_changed()
 
     def _send_response(self, client_sock, response):
-        """Send a length-prefixed JSON response to a client."""
+        """Queue a length-prefixed JSON response and write what the socket takes.
+
+        Never uses ``sendall``: these sockets are non-blocking, so a response
+        larger than the kernel send buffer (base64 renders and screenshots
+        routinely are) would raise ``BlockingIOError`` having already written a
+        partial frame. The caller's framing would then be desynced for every
+        subsequent message. Anything not accepted now stays queued and is
+        flushed by :meth:`_flush_outbound` on the next tick.
+        """
         resp_bytes = json.dumps(_json_safe(response)).encode("utf-8")
-        header = _HEADER_STRUCT.pack(len(resp_bytes))
-        client_sock.sendall(header + resp_bytes)
+        buf = self.outbound.get(client_sock)
+        if buf is None:
+            buf = self.outbound[client_sock] = OutboundBuffer()
+        buf.append(frame(resp_bytes))
+        if buf.flush(client_sock):
+            # Fully written — drop the entry so the common case leaves nothing
+            # for _flush_outbound to walk on every tick.
+            self.outbound.pop(client_sock, None)
+
+    def _flush_outbound(self):
+        """Drain queued responses for every client with pending bytes."""
+        for client_sock in list(self.outbound):
+            buf = self.outbound.get(client_sock)
+            if buf is None or not buf.pending:
+                continue
+            try:
+                if buf.flush(client_sock):
+                    self.outbound.pop(client_sock, None)
+            except Exception as e:
+                self._disconnect_client(client_sock, f"Error writing to client: {e!s}", MSG_WARNING)
 
     def process_server(self):
         """Process server operations (called by timer)"""
         if not self.running:
             return
 
+        # A handler is on the stack and is pumping the event loop to keep the
+        # GUI alive. Doing anything here would run a second command inside the
+        # first; the outer handler resumes this loop when it returns.
+        if self._in_dispatch:
+            return
+
         try:
+            # Drain any backlog first so a client that was mid-response gets the
+            # rest of its frame before we take on more work.
+            self._flush_outbound()
+
             # Accept new connections (loop until no pending or at capacity)
             if self.socket:
                 while len(self.clients) < self.MAX_CLIENTS:
@@ -390,13 +517,21 @@ class QgisMCPServer(QObject):
                                     {"status": "error", "message": f"Invalid JSON: {e!s}"},
                                 )
                                 continue
-                            response = self.execute_command(command)
+                            self._in_dispatch = True
+                            try:
+                                response = self.execute_command(command)
+                            finally:
+                                self._in_dispatch = False
                             self._send_response(client_sock, response)
                         self.clients[client_sock] = buf
                     else:
                         self._disconnect_client(client_sock)
                 except BlockingIOError:
                     pass
+                except OutboundOverflow as e:
+                    # The peer stopped reading while we kept producing. Nothing
+                    # can be delivered, so drop it rather than grow without bound.
+                    self._disconnect_client(client_sock, f"Client not reading: {e!s}", MSG_WARNING)
                 except Exception as e:
                     self._disconnect_client(client_sock, f"Error with client: {e!s}", MSG_WARNING)
 
@@ -1139,18 +1274,50 @@ class QgisMCPServer(QObject):
         }
 
     def batch(self, commands, **kwargs):
-        """Execute multiple commands in sequence, return array of results."""
-        return [
-            self._dispatch({"type": cmd.get("type"), "params": cmd.get("params", {})})
-            for cmd in commands
-        ]
+        """Execute multiple commands in sequence, return array of results.
 
-    def execute_processing(self, algorithm, parameters, **kwargs):
+        Destructive commands are refused here, not only in the MCP server: the
+        socket is reachable by any local process, so a guard that lives solely
+        on the client side is advisory. Rejecting one command does not abort the
+        batch — the refusal is reported in that command's slot.
+        """
+        results = []
+        for cmd in commands:
+            cmd_type = cmd.get("type")
+            if cmd_type in BATCH_BLOCKED_COMMANDS:
+                QgsMessageLog.logMessage(
+                    f"Refused {cmd_type!r} inside batch", self.LOG_TAG, MSG_WARNING
+                )
+                results.append(
+                    {
+                        "status": "error",
+                        "message": (
+                            f"Command {cmd_type!r} is not allowed in batch — "
+                            "call it individually so confirmation can be requested"
+                        ),
+                    }
+                )
+                continue
+            results.append(self._dispatch({"type": cmd_type, "params": cmd.get("params", {})}))
+        return results
+
+    # Below the client's TIMEOUT_LONG (60s) so the plugin gives up — and says
+    # why — before the client abandons the request and leaves QGIS still working.
+    _PROCESSING_TIMEOUT = 55
+
+    def execute_processing(self, algorithm, parameters, timeout=None, **kwargs):
         try:
             import processing
 
             QgsMessageLog.logMessage(f"Processing: {algorithm}", self.LOG_TAG, MSG_INFO)
-            result = processing.run(algorithm, parameters)
+            budget = self._PROCESSING_TIMEOUT if timeout is None else float(timeout)
+            feedback = _ResponsiveFeedback(budget)
+            result = processing.run(algorithm, parameters, feedback=feedback)
+            if feedback.timed_out:
+                raise Exception(
+                    f"Processing cancelled after {budget:g}s. Pass a larger 'timeout', "
+                    "or run heavy raster work with GDAL outside QGIS."
+                )
             return {"algorithm": algorithm, "result": {k: str(v) for k, v in result.items()}}
         except Exception as e:
             raise Exception(f"Processing error: {e!s}") from e

--- a/qgis_mcp_plugin/plugin.py
+++ b/qgis_mcp_plugin/plugin.py
@@ -195,6 +195,7 @@ from .wire import (
     OutboundBuffer,
     OutboundOverflow,
     frame,
+    zip_strict,
 )
 
 _DEFAULT_HOST = "localhost"
@@ -1863,7 +1864,7 @@ class QgisMCPServer(QObject):
                 renderer.setBlueContrastEnhancement,
             )
             ranges = []
-            for setter, b in zip(setters, bands, strict=True):
+            for setter, b in zip_strict(setters, bands):
                 lo, hi = self._band_range(provider, b, min_value, max_value)
                 enhancement = QgsContrastEnhancement(provider.dataType(b))
                 enhancement.setContrastEnhancementAlgorithm(
@@ -3592,7 +3593,7 @@ class QgisMCPServer(QObject):
         siblings = list(parent.children())
         slots = sorted(siblings.index(n) for n in nodes)
         new_order = list(siblings)
-        for slot, node in zip(slots, nodes, strict=True):
+        for slot, node in zip_strict(slots, nodes):
             new_order[slot] = node
         clones = [n.clone() for n in new_order]
         parent.insertChildNodes(0, clones)

--- a/qgis_mcp_plugin/wire.py
+++ b/qgis_mcp_plugin/wire.py
@@ -1,0 +1,103 @@
+"""Stdlib-only wire helpers for the plugin's socket server.
+
+Deliberately free of ``qgis`` imports so the framing logic can be unit-tested
+outside QGIS — the plugin-side mirror of ``qgis_mcp.protocol`` on the client
+side. Must stay importable on Python 3.9 (QGIS 3.28 ships it).
+"""
+
+from __future__ import annotations
+
+import errno
+import struct
+
+HEADER_STRUCT = struct.Struct(">I")  # 4-byte big-endian uint32 length prefix
+RECV_CHUNK_SIZE = 65536
+MAX_MESSAGE_SIZE = 10 * 1024 * 1024  # 10 MB — inbound frame/buffer limit
+
+# Cap on bytes queued for one client that has stopped reading. Renders and
+# screenshots are base64 and can legitimately reach several MB, so this sits
+# well above a single large response but still bounds a stalled peer.
+MAX_OUTBOUND_BYTES = 64 * 1024 * 1024  # 64 MB
+
+# Commands refused inside a `batch`. Mirrors qgis_mcp.protocol's frozenset of
+# the same name; tests assert the two stay identical. Enforced here (plugin
+# side) as well as in the MCP server so a direct socket client cannot slip a
+# destructive command past the confirmation flow by wrapping it in a batch.
+BATCH_BLOCKED_COMMANDS = frozenset(
+    {
+        "execute_code",
+        "remove_layer",
+        "delete_features",
+        "set_setting",
+        "reload_plugin",
+        "rollback_edits",
+        "execute_connection_sql",
+        "import_layer_to_connection",
+    }
+)
+
+# Errnos meaning "socket buffer full, try again later" rather than a real error.
+_WOULD_BLOCK = frozenset({errno.EAGAIN, errno.EWOULDBLOCK})
+
+
+class OutboundOverflow(Exception):
+    """Raised when a client's unsent backlog exceeds ``MAX_OUTBOUND_BYTES``."""
+
+
+def frame(payload: bytes) -> bytes:
+    """Return *payload* prefixed with its 4-byte big-endian length header."""
+    return HEADER_STRUCT.pack(len(payload)) + payload
+
+
+class OutboundBuffer:
+    """Bytes queued for one non-blocking client socket.
+
+    ``socket.sendall`` cannot be used on a non-blocking socket: when the kernel
+    send buffer fills mid-payload it raises ``BlockingIOError`` having already
+    written an unknown prefix, leaving a half-written frame on the wire and a
+    permanently desynced peer. This queues the remainder instead and drains it
+    on later event-loop ticks.
+    """
+
+    def __init__(self, max_bytes: int = MAX_OUTBOUND_BYTES) -> None:
+        self._buf = bytearray()
+        self._max_bytes = max_bytes
+
+    def __len__(self) -> int:
+        return len(self._buf)
+
+    @property
+    def pending(self) -> bool:
+        """True when bytes are still waiting to be written."""
+        return bool(self._buf)
+
+    def append(self, data: bytes) -> None:
+        """Queue *data*, raising :class:`OutboundOverflow` past the cap."""
+        if len(self._buf) + len(data) > self._max_bytes:
+            raise OutboundOverflow(
+                f"outbound backlog would exceed {self._max_bytes} bytes "
+                f"({len(self._buf)} queued, {len(data)} more) — client is not reading"
+            )
+        self._buf.extend(data)
+
+    def flush(self, sock) -> bool:
+        """Write as much as the socket accepts. True when fully drained.
+
+        Partial writes and would-block conditions leave the remainder queued
+        for the next call. Real socket errors propagate.
+        """
+        while self._buf:
+            try:
+                sent = sock.send(memoryview(self._buf))
+            except BlockingIOError:
+                return False
+            except OSError as exc:
+                if exc.errno in _WOULD_BLOCK:
+                    return False
+                raise
+            if sent <= 0:
+                # A non-blocking send returning 0 means no progress is possible
+                # right now; treat it as would-block rather than spinning.
+                return False
+            del self._buf[:sent]
+        return True

--- a/qgis_mcp_plugin/wire.py
+++ b/qgis_mcp_plugin/wire.py
@@ -49,6 +49,25 @@ def frame(payload: bytes) -> bytes:
     return HEADER_STRUCT.pack(len(payload)) + payload
 
 
+def zip_strict(*iterables):
+    """``zip(*iterables, strict=True)`` that also works on Python 3.9.
+
+    The ``strict`` keyword landed in 3.10, and QGIS bundles 3.9 well past the
+    plugin's 3.28 minimum. Calling it there raises "zip() takes no keyword
+    arguments" at call time — an error CI never sees, because the test suite
+    runs on a newer interpreter.
+
+    Inputs are materialised so length can be compared up front; every call
+    site here passes short, already-realised sequences.
+    """
+    columns = [list(it) for it in iterables]
+    if len({len(c) for c in columns}) > 1:
+        raise ValueError(
+            "zip_strict() argument lengths differ: " + ", ".join(str(len(c)) for c in columns)
+        )
+    return zip(*columns)
+
+
 class OutboundBuffer:
     """Bytes queued for one non-blocking client socket.
 

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -1278,20 +1278,32 @@ async def get_raster_info(
 @mcp.tool(
     title="Execute Processing",
     description="Execute a QGIS Processing algorithm. Use get_algorithm_help to discover parameters. "
-    "Layer params accept layer IDs or file paths. Set OUTPUT to 'memory:' for temp layers.",
+    "Layer params accept layer IDs or file paths. Set OUTPUT to 'memory:' for temp layers. "
+    "timeout: seconds before the algorithm is cancelled (default 55). Raise it for heavy "
+    "raster work, but note that long jobs hold the QGIS session for their duration.",
 )
 async def execute_processing(
     ctx: Context,
     algorithm: str,
     parameters: dict,
+    timeout: int | None = None,
     instance: str | None = None,
 ) -> dict:
     await ctx.info(f"Running algorithm: {algorithm}")
     await ctx.report_progress(0, 100)
+    params: dict[str, Any] = {"algorithm": algorithm, "parameters": parameters}
+    # Keep the two deadlines ordered: the plugin must give up first so the
+    # failure comes back as a real message instead of the client timing out
+    # while QGIS keeps grinding on an orphaned job.
+    if timeout is None:
+        socket_timeout = TIMEOUT_LONG
+    else:
+        params["timeout"] = timeout
+        socket_timeout = int(timeout) + 5
     result = await _send(
         "execute_processing",
-        {"algorithm": algorithm, "parameters": parameters},
-        timeout=TIMEOUT_LONG,
+        params,
+        timeout=socket_timeout,
         instance=instance,
     )
     await ctx.report_progress(100, 100)

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -290,6 +290,39 @@ async def test_execute_processing_uses_long_timeout(mock_connection):
 
 
 @pytest.mark.asyncio
+async def test_execute_processing_default_sends_no_plugin_timeout(mock_connection):
+    """Without an explicit timeout the plugin applies its own default."""
+    mock_connection.send_command.return_value = {
+        "status": "success",
+        "result": {"algorithm": "test", "result": {}},
+    }
+    from qgis_mcp.server import execute_processing
+
+    await execute_processing(_make_ctx(), algorithm="native:buffer", parameters={})
+    sent_params = mock_connection.send_command.call_args[0][1]
+    assert "timeout" not in sent_params
+
+
+@pytest.mark.asyncio
+async def test_execute_processing_custom_timeout_outlives_plugin_deadline(mock_connection):
+    """The socket must outlast the plugin's deadline.
+
+    If the client gave up first, a slow algorithm would surface as an opaque
+    socket timeout while QGIS kept working on an orphaned job.
+    """
+    mock_connection.send_command.return_value = {
+        "status": "success",
+        "result": {"algorithm": "test", "result": {}},
+    }
+    from qgis_mcp.server import execute_processing
+
+    await execute_processing(_make_ctx(), algorithm="native:buffer", parameters={}, timeout=300)
+    args, kwargs = mock_connection.send_command.call_args
+    assert args[1]["timeout"] == 300, "plugin must receive the algorithm deadline"
+    assert kwargs["timeout"] > 300, "socket timeout must outlast the plugin deadline"
+
+
+@pytest.mark.asyncio
 async def test_render_map_returns_image_content(mock_connection):
     mock_connection.send_command.return_value = {
         "status": "success",
@@ -1445,9 +1478,7 @@ async def test_add_bookmark_tool(mock_connection):
     from qgis_mcp.server import add_bookmark
 
     ctx = _make_ctx()
-    output = await add_bookmark(
-        ctx, name="Munich", xmin=11.3, ymin=48.0, xmax=11.8, ymax=48.3
-    )
+    output = await add_bookmark(ctx, name="Munich", xmin=11.3, ymin=48.0, xmax=11.8, ymax=48.3)
     assert output["ok"] is True
     call_params = mock_connection.send_command.call_args[0][1]
     assert call_params["name"] == "Munich"
@@ -1579,9 +1610,7 @@ async def test_list_processing_models(mock_connection):
 
     result = await list_processing_models(_make_ctx())
     assert result["count"] == 1
-    mock_connection.send_command.assert_called_once_with(
-        "list_processing_models", None, timeout=30
-    )
+    mock_connection.send_command.assert_called_once_with("list_processing_models", None, timeout=30)
 
 
 @pytest.mark.asyncio
@@ -1648,9 +1677,7 @@ async def test_export_layer_with_reproject(mock_connection):
     }
     from qgis_mcp.server import export_layer
 
-    await export_layer(
-        _make_ctx(), layer_id="lyr", output_path="out.gpkg", target_crs="EPSG:4326"
-    )
+    await export_layer(_make_ctx(), layer_id="lyr", output_path="out.gpkg", target_crs="EPSG:4326")
     mock_connection.send_command.assert_called_once_with(
         "export_layer",
         {
@@ -2197,7 +2224,9 @@ async def test_compound_field_and_analysis_dispatch():
         assert params["stats"] == [0, 2]
         assert params["band"] == 1
 
-        await client.call_tool("processing", {"action": "run_model", "params": {"model": "model:x"}})
+        await client.call_tool(
+            "processing", {"action": "run_model", "params": {"model": "model:x"}}
+        )
         cmd, params = send.call_args[0][:2]
         assert cmd == "run_model"
         assert params == {"model": "model:x", "parameters": {}}
@@ -2305,7 +2334,9 @@ def test_unknown_instance_error_lists_configured_names():
 
     with (
         patch.dict(os.environ, {"QGIS_MCP_INSTANCES": "a=9876,b=9877"}, clear=True),
-        pytest.raises(ValueError, match=r"Unknown QGIS instance: 'nope'.*Configured instances: a, b"),
+        pytest.raises(
+            ValueError, match=r"Unknown QGIS instance: 'nope'.*Configured instances: a, b"
+        ),
     ):
         resolve_instance("nope")
 
@@ -2557,7 +2588,13 @@ async def test_every_tool_forwards_instance():
 
     def dummy(annotation):
         text = str(annotation)
-        for needle, value in (("list", []), ("dict", {}), ("bool", False), ("float", 1.0), ("int", 1)):
+        for needle, value in (
+            ("list", []),
+            ("dict", {}),
+            ("bool", False),
+            ("float", 1.0),
+            ("int", 1),
+        ):
             if needle in text:
                 return value
         return "x"

--- a/tests/test_py39_compat.py
+++ b/tests/test_py39_compat.py
@@ -77,6 +77,36 @@ def test_no_runtime_evaluated_pep604_annotations():
     )
 
 
+    # keyword arguments added to builtins after 3.9 -> "takes no keyword arguments"
+NEWER_THAN_39_KWARGS = {
+    "zip": {"strict"},
+}
+
+
+def test_no_post_39_builtin_keyword_arguments():
+    """`zip(a, b, strict=True)` raises TypeError on 3.9.
+
+    Not a syntax error and not an import error — it fails only when that line
+    executes, which is why `set_layer_order` and `set_raster_style` shipped
+    broken while the suite stayed green on 3.12.
+    """
+    offenders = []
+    for name, src in _plugin_sources():
+        for node in ast.walk(ast.parse(src)):
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+                continue
+            banned = NEWER_THAN_39_KWARGS.get(node.func.id)
+            if not banned:
+                continue
+            for kw in node.keywords:
+                if kw.arg in banned:
+                    offenders.append(f"{name}:{node.lineno} {node.func.id}({kw.arg}=)")
+    assert not offenders, (
+        "builtin keyword argument newer than Python 3.9 — TypeError on the "
+        f"interpreter QGIS bundles. Found: {offenders}"
+    )
+
+
 def test_plugin_modules_parse_under_py39_grammar():
     """Nothing in the plugin may use syntax newer than 3.9 (e.g. match/case)."""
     for name, src in _plugin_sources():

--- a/tests/test_py39_compat.py
+++ b/tests/test_py39_compat.py
@@ -1,0 +1,87 @@
+"""Static guard: the plugin must stay importable and runnable on Python 3.9.
+
+QGIS bundles its own interpreter, and that is still Python 3.9 well past the
+plugin's 3.28 minimum — QGIS 3.42 ships 3.9. The test suite runs on 3.12, so
+nothing here is caught at runtime: a PEP 604 union inside isinstance() imports
+cleanly on CI and raises TypeError on a real QGIS install. That is exactly how
+``isinstance(value, int | float | ...)`` shipped and broke every feature read.
+"""
+
+import ast
+import os
+
+PLUGIN_DIR = os.path.join(os.path.dirname(__file__), "..", "qgis_mcp_plugin")
+
+
+def _plugin_sources():
+    for name in sorted(os.listdir(PLUGIN_DIR)):
+        if name.endswith(".py"):
+            path = os.path.join(PLUGIN_DIR, name)
+            with open(path, encoding="utf-8") as fh:
+                yield name, fh.read()
+
+
+def _has_future_annotations(tree):
+    return any(
+        isinstance(node, ast.ImportFrom)
+        and node.module == "__future__"
+        and any(a.name == "annotations" for a in node.names)
+        for node in tree.body
+    )
+
+
+def test_no_pep604_unions_in_isinstance():
+    """`isinstance(x, A | B)` is a TypeError on Python 3.9."""
+    offenders = []
+    for name, src in _plugin_sources():
+        for node in ast.walk(ast.parse(src)):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in ("isinstance", "issubclass")
+                and len(node.args) == 2
+                and isinstance(node.args[1], ast.BinOp)
+                and isinstance(node.args[1].op, ast.BitOr)
+            ):
+                offenders.append(f"{name}:{node.lineno}")
+    assert not offenders, (
+        "PEP 604 union inside isinstance/issubclass — raises TypeError on the "
+        f"Python 3.9 QGIS bundles. Use the tuple form. Found at: {offenders}"
+    )
+
+
+def test_no_runtime_evaluated_pep604_annotations():
+    """Function signatures are evaluated at import; `X | Y` there breaks 3.9.
+
+    Only flagged for modules without ``from __future__ import annotations``,
+    which defers evaluation and makes the syntax safe.
+    """
+    offenders = []
+    for name, src in _plugin_sources():
+        tree = ast.parse(src)
+        if _has_future_annotations(tree):
+            continue
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            annotations = [a.annotation for a in node.args.args if a.annotation]
+            annotations += [a.annotation for a in node.args.kwonlyargs if a.annotation]
+            if node.returns is not None:
+                annotations.append(node.returns)
+            for ann in annotations:
+                if isinstance(ann, ast.BinOp) and isinstance(ann.op, ast.BitOr):
+                    offenders.append(f"{name}:{node.lineno} ({node.name})")
+    assert not offenders, (
+        "PEP 604 union in a signature of a module lacking "
+        f"`from __future__ import annotations` — fails to import on 3.9: {offenders}"
+    )
+
+
+def test_plugin_modules_parse_under_py39_grammar():
+    """Nothing in the plugin may use syntax newer than 3.9 (e.g. match/case)."""
+    for name, src in _plugin_sources():
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            assert not isinstance(node, ast.Match), (
+                f"{name}: match/case statement requires Python 3.10; QGIS ships 3.9"
+            )

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -294,3 +294,13 @@ def test_framing_stays_aligned_across_successive_large_responses():
         client.disconnect()
         thread.join(timeout=5)
         listener.close()
+
+
+def test_zip_strict_matches_builtin_behaviour():
+    assert list(wire.zip_strict([1, 2], "ab")) == [(1, "a"), (2, "b")]
+
+
+def test_zip_strict_rejects_length_mismatch():
+    """Mirrors zip(strict=True): silently truncating is the bug it prevents."""
+    with pytest.raises(ValueError):
+        list(wire.zip_strict([1, 2, 3], "ab"))

--- a/tests/test_wire.py
+++ b/tests/test_wire.py
@@ -1,0 +1,296 @@
+"""Unit tests for the plugin-side wire helpers (no QGIS required).
+
+Covers the non-blocking outbound path: on a non-blocking socket a large
+response cannot be written with sendall(), and a partial write that is not
+re-queued desyncs the client's length-prefixed framing permanently.
+"""
+
+import importlib.util
+import os
+import socket
+import sys
+import threading
+import time
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from qgis_mcp.client import QgisMCPClient
+from qgis_mcp.protocol import BATCH_BLOCKED_COMMANDS as CLIENT_BLOCKED
+
+
+def _load_wire():
+    """Import wire.py by path.
+
+    ``qgis_mcp_plugin/__init__.py`` imports the plugin (and therefore ``qgis``),
+    so the package cannot be imported outside QGIS. Loading the module file
+    directly is what keeps these helpers unit-testable — and asserts they stay
+    free of QGIS imports.
+    """
+    path = os.path.join(os.path.dirname(__file__), "..", "qgis_mcp_plugin", "wire.py")
+    spec = importlib.util.spec_from_file_location("qgis_mcp_plugin_wire", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+wire = _load_wire()
+
+HEADER_STRUCT = wire.HEADER_STRUCT
+BATCH_BLOCKED_COMMANDS = wire.BATCH_BLOCKED_COMMANDS
+OutboundBuffer = wire.OutboundBuffer
+OutboundOverflow = wire.OutboundOverflow
+frame = wire.frame
+
+
+class FakeSocket:
+    """Non-blocking socket accepting a bounded number of bytes per send()."""
+
+    def __init__(self, chunk=None, capacity=None, error=None):
+        self.chunk = chunk  # max bytes accepted per send() call
+        self.capacity = capacity  # total bytes before raising BlockingIOError
+        self.error = error  # exception to raise on send()
+        self.sent = bytearray()
+
+    def send(self, view):
+        if self.error is not None:
+            raise self.error
+        n = len(view)
+        if self.chunk is not None:
+            n = min(n, self.chunk)
+        if self.capacity is not None:
+            room = self.capacity - len(self.sent)
+            if room <= 0:
+                raise BlockingIOError("send buffer full")
+            n = min(n, room)
+        self.sent.extend(bytes(view[:n]))
+        return n
+
+
+def test_frame_prefixes_length():
+    assert frame(b"abc") == HEADER_STRUCT.pack(3) + b"abc"
+
+
+def test_flush_drains_when_socket_accepts_everything():
+    buf = OutboundBuffer()
+    sock = FakeSocket()
+    buf.append(frame(b"hello"))
+    assert buf.flush(sock) is True
+    assert buf.pending is False
+    assert bytes(sock.sent) == frame(b"hello")
+
+
+def test_partial_writes_are_requeued_and_resumed():
+    """The core regression: a 1 MB payload written 1 KB at a time must arrive intact."""
+    payload = frame(b"x" * (1024 * 1024))
+    buf = OutboundBuffer()
+    buf.append(payload)
+    sock = FakeSocket(chunk=1024)
+
+    assert buf.flush(sock) is True
+    assert bytes(sock.sent) == payload
+
+
+def test_would_block_leaves_remainder_queued_then_resumes():
+    """A full kernel buffer must not lose bytes — the frame resumes exactly where it stopped."""
+    payload = frame(b"y" * 5000)
+    buf = OutboundBuffer()
+    buf.append(payload)
+
+    sock = FakeSocket(capacity=2000)
+    assert buf.flush(sock) is False, "should report not-drained when the socket blocks"
+    assert buf.pending is True
+    assert len(sock.sent) == 2000
+
+    # Peer drains; the rest must complete the frame without duplication or loss.
+    sock.capacity = None
+    assert buf.flush(sock) is True
+    assert bytes(sock.sent) == payload
+
+
+def test_zero_return_is_treated_as_would_block():
+    buf = OutboundBuffer()
+    buf.append(b"data")
+    sock = FakeSocket(chunk=0)
+    assert buf.flush(sock) is False
+    assert buf.pending is True
+
+
+def test_eagain_oserror_is_treated_as_would_block():
+    import errno
+
+    buf = OutboundBuffer()
+    buf.append(b"data")
+    sock = FakeSocket(error=OSError(errno.EAGAIN, "temporarily unavailable"))
+    assert buf.flush(sock) is False
+    assert buf.pending is True
+
+
+def test_real_socket_error_propagates():
+    import errno
+
+    buf = OutboundBuffer()
+    buf.append(b"data")
+    sock = FakeSocket(error=OSError(errno.EPIPE, "broken pipe"))
+    with pytest.raises(OSError):
+        buf.flush(sock)
+
+
+def test_multiple_frames_queue_in_order():
+    buf = OutboundBuffer()
+    buf.append(frame(b"one"))
+    buf.append(frame(b"two"))
+    sock = FakeSocket(chunk=3)
+    assert buf.flush(sock) is True
+    assert bytes(sock.sent) == frame(b"one") + frame(b"two")
+
+
+def test_overflow_raises_when_client_stops_reading():
+    buf = OutboundBuffer(max_bytes=100)
+    buf.append(b"z" * 90)
+    with pytest.raises(OutboundOverflow):
+        buf.append(b"z" * 20)
+
+
+def test_overflow_boundary_is_inclusive():
+    buf = OutboundBuffer(max_bytes=100)
+    buf.append(b"z" * 100)  # exactly at cap is allowed
+    assert len(buf) == 100
+
+
+def test_plugin_and_client_batch_blocklists_match():
+    """Both sides must refuse the same commands, or the guard is only advisory."""
+    assert BATCH_BLOCKED_COMMANDS == CLIENT_BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the real client against a server loop mirroring the plugin's
+# ---------------------------------------------------------------------------
+
+
+def _serve_once(listener, payload_sizes, ready):
+    """Mimic the plugin's non-blocking accept/read/dispatch/write loop.
+
+    Mirrors QgisMCPServer.process_server: non-blocking sockets throughout,
+    responses queued through OutboundBuffer and drained across iterations.
+    """
+    import json
+    import select
+
+    clients = {}
+    outbound = {}
+    ready.set()
+    replies_left = len(payload_sizes)
+    sizes = list(payload_sizes)
+    deadline = time.monotonic() + 30
+
+    while time.monotonic() < deadline:
+        # Drain pending writes first, exactly as _flush_outbound does.
+        for sock in list(outbound):
+            buf = outbound[sock]
+            if buf.flush(sock):
+                outbound.pop(sock, None)
+
+        readable, _, _ = select.select([listener, *clients], [], [], 0.01)
+        for sock in readable:
+            if sock is listener:
+                conn, _ = listener.accept()
+                conn.setblocking(False)
+                clients[conn] = b""
+                continue
+            try:
+                data = sock.recv(RECV_CHUNK)
+            except BlockingIOError:
+                continue
+            if not data:
+                clients.pop(sock, None)
+                continue
+            buf = clients[sock] + data
+            while len(buf) >= 4:
+                msg_len = HEADER_STRUCT.unpack(buf[:4])[0]
+                if len(buf) < 4 + msg_len:
+                    break
+                json.loads(buf[4 : 4 + msg_len].decode("utf-8"))
+                buf = buf[4 + msg_len :]
+                body = json.dumps(
+                    {"status": "success", "result": {"blob": "A" * sizes.pop(0)}}
+                ).encode("utf-8")
+                out = outbound.setdefault(sock, OutboundBuffer())
+                out.append(frame(body))
+                out.flush(sock)
+                replies_left -= 1
+            clients[sock] = buf
+
+        if replies_left == 0 and not any(b.pending for b in outbound.values()):
+            break
+
+    for sock in clients:
+        sock.close()
+
+
+RECV_CHUNK = 65536
+
+
+def test_large_response_survives_non_blocking_socket():
+    """An 8 MB response must arrive intact through a non-blocking server socket.
+
+    This is the regression the fix exists for: ``sendall`` on a non-blocking
+    socket raises BlockingIOError partway through a payload this size, leaving a
+    truncated frame and a client whose framing never recovers.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(5)
+    listener.setblocking(False)
+    port = listener.getsockname()[1]
+
+    blob_size = 8 * 1024 * 1024
+    ready = threading.Event()
+    thread = threading.Thread(target=_serve_once, args=(listener, [blob_size], ready), daemon=True)
+    thread.start()
+    ready.wait(5)
+
+    client = QgisMCPClient(host="127.0.0.1", port=port)
+    try:
+        assert client.connect(), "client failed to connect"
+        response = client.send_command("ping", timeout=30)
+        assert response["status"] == "success"
+        assert len(response["result"]["blob"]) == blob_size
+    finally:
+        client.disconnect()
+        thread.join(timeout=5)
+        listener.close()
+
+
+def test_framing_stays_aligned_across_successive_large_responses():
+    """Consecutive big frames must not bleed into each other.
+
+    A partial write that is dropped rather than re-queued desyncs every
+    subsequent message, so the second response is the one that exposes it.
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(5)
+    listener.setblocking(False)
+    port = listener.getsockname()[1]
+
+    sizes = [3 * 1024 * 1024, 2 * 1024 * 1024, 1024]
+    ready = threading.Event()
+    thread = threading.Thread(target=_serve_once, args=(listener, sizes, ready), daemon=True)
+    thread.start()
+    ready.wait(5)
+
+    client = QgisMCPClient(host="127.0.0.1", port=port)
+    try:
+        assert client.connect()
+        for expected in sizes:
+            response = client.send_command("ping", timeout=30)
+            assert response["status"] == "success"
+            assert len(response["result"]["blob"]) == expected
+    finally:
+        client.disconnect()
+        thread.join(timeout=5)
+        listener.close()


### PR DESCRIPTION
Three defects found while reading the code, each confirmed against a live QGIS 3.42.1. Two of them break the plugin outright on the Python that QGIS actually ships.

## 1. Large responses are silently truncated

`_send_response` uses `sendall(header + resp_bytes)`, but client sockets are non-blocking (`plugin.py`, `client_sock.setblocking(False)`). On a non-blocking socket `sendall` raises `BlockingIOError` once the kernel buffer fills, **having already written an unknown prefix** — and that exception is swallowed by the polling loop's `except BlockingIOError: pass`. The result is a half-written frame and a client whose length-prefixed framing never recovers.

Measured on loopback: a single `send()` accepts **327,212 of 8,388,612 bytes**. Any `render_map_base64` or `get_canvas_screenshot` response beyond a few hundred KB is at risk.

Responses now queue through an `OutboundBuffer` that re-queues whatever the socket did not accept and drains it on later timer ticks, with a cap that disconnects a peer which has stopped reading. Verified end to end: an 8 MB response now round-trips through the real client; against the previous code the same test raises `BlockingIOError` mid-frame and the client dies with `ConnectionError: Connection closed`.

## 2. PEP 604 unions in `isinstance` — breaks every feature read on Python 3.9

```python
isinstance(value, int | float | str | bool | type(None))
```

in `_convert_to_python_type` / `_convert_attribute` requires Python 3.10. QGIS bundles its own interpreter and it is still 3.9 well past the declared 3.28 minimum — **QGIS 3.42.1 ships 3.9** — so this raises:

```
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

on every path that reads feature attributes: `get_layer_features`, add/update/delete verification, `execute_sql`, `evaluate_expression`, edit sessions. **16 of the live tests fail on it.**

## 3. `zip(..., strict=True)` — same story

`set_layer_order` and `set_raster_style` both use it. The keyword arrived in 3.10, so on 3.9:

```
TypeError: zip() takes no keyword arguments
```

`set_layer_order` was dead on arrival for every QGIS 3.x on Python 3.9.

## Why 2 and 3 happened — the lint config

Both are the lint config pushing toward 3.10-only constructs while CI runs 3.12, so nothing catches it:

- **UP038** rewrites `isinstance(x, (A, B))` into `isinstance(x, A | B)`
- **B905** flags bare `zip()` and instructs "add explicit value for parameter `strict=`"

`pyproject.toml` already ignored UP038 for `qgis_mcp_plugin/*` — someone hit this before and fixed the symptom rather than the rule. This PR adds B905 alongside it with the reasoning written down, and adds `tests/test_py39_compat.py`: an AST guard that fails on the whole class of constructs which import cleanly on 3.12 and fail at runtime on 3.9 (PEP 604 unions in `isinstance`/`issubclass`, unions in signatures of modules lacking `from __future__ import annotations`, post-3.9 builtin keywords, `match`/`case`).

## Also included

- **Long processing froze the QGIS UI.** `processing.run()` ran synchronously inside the timer callback, blocking the Qt event loop for its duration. It now runs with a feedback object that pumps the event loop and enforces a deadline below the client's `TIMEOUT_LONG`, so a slow algorithm returns a real message instead of an opaque socket timeout. `execute_processing` takes an optional `timeout`.
- **Batch blocklist enforced server-side.** `BATCH_BLOCKED_COMMANDS` was checked only in the MCP server, so a direct socket client could wrap `execute_code` in a batch and bypass the confirmation flow. Now enforced in the plugin too, against a shared frozenset a test pins to the client's copy.
- **Re-entrancy guard.** `render_map`'s nested `QEventLoop` (and now the processing feedback) re-fire the server timer, which could run a second client's command inside the first one's handler. `_in_dispatch` makes `process_server` a no-op while a handler is on the stack.

## Verification

Live suite against QGIS 3.42.1: **19 failed / 34 passed → 3 failed / 50 passed**.

The 3 remaining failures are test-vs-implementation drift that predates this branch and fails byte-identically on pristine `main` with only the 3.9 fix applied — the test expects `execute_code` to return `"output"` (the plugin returns `"stdout"`), expects `_geometry` as a WKT string (the plugin returns a dict), and expects updating a nonexistent fid to succeed (the plugin raises). I have not touched those, since changing behaviour to match a test is the wrong direction without knowing which side is intended.

Unit suite: 249 passing.

Framing helpers moved to `qgis_mcp_plugin/wire.py`, kept free of `qgis` imports so they are unit-testable outside QGIS — which is how the 8 MB round-trip test runs in CI.