### PR TITLE
feat(confirm): QGIS_MCP_AUTO_CONFIRM opt-out for destructive-tool elicitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ Groups: `system`, `project`, `layer`, `features`, `selection`, `style`, `canvas`
 | `QGIS_MCP_LOG_FILE` | `~/.local/share/qgis-mcp/server.log` | Log file path (empty to disable) |
 | `QGIS_MCP_LOG_LEVEL` | `INFO` | File log level |
 | `QGIS_MCP_TOOL_MODE` | `granular` | `granular` (118 tools) or `compound` (27 grouped) |
+| `QGIS_MCP_AUTO_CONFIRM` | _(unset)_ | `1`/`true`/`yes`/`on` skips the confirmation elicitation on destructive tools (remove_layer, delete_features, execute_code, ...). Use only with a client whose own tool-call gate already covers them - the elicitation is then a redundant second prompt. |
 
 ### Authentication
 

--- a/src/qgis_mcp/server.py
+++ b/src/qgis_mcp/server.py
@@ -462,7 +462,14 @@ async def _confirm_destructive(ctx: Context, message: str) -> bool:
     Returns True if client doesn't support elicitation (fail-open), since
     the tool is already marked destructive via ToolAnnotations and the client
     can gate execution at the tool-call level.
+
+    ``QGIS_MCP_AUTO_CONFIRM`` (1/true/yes/on) skips the elicitation entirely,
+    for clients whose own tool-call gate makes this prompt a redundant second
+    confirmation. Read per call so a long-lived server honors changes.
     """
+    if os.environ.get("QGIS_MCP_AUTO_CONFIRM", "").strip().lower() in {"1", "true", "yes", "on"}:
+        logger.info("QGIS_MCP_AUTO_CONFIRM set - skipping confirmation elicitation")
+        return True
     try:
         response = await ctx.elicit(message=message, schema=_ConfirmSchema)
     except McpError:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1112,6 +1112,33 @@ async def test_remove_layer_confirmed_by_user(mock_connection):
     assert output == {"ok": True}
 
 
+@pytest.mark.asyncio
+async def test_auto_confirm_skips_elicitation(mock_connection):
+    """QGIS_MCP_AUTO_CONFIRM=1 proceeds without ever eliciting."""
+    mock_connection.send_command.return_value = {"status": "success", "result": {"ok": True}}
+    from qgis_mcp.server import remove_layer
+
+    ctx = _make_ctx(elicitation="decline")
+    with patch.dict(os.environ, {"QGIS_MCP_AUTO_CONFIRM": "1"}):
+        output = await remove_layer(ctx, layer_id="test_layer")
+    assert output == {"ok": True}
+    ctx.elicit.assert_not_called()
+    mock_connection.send_command.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_confirm_falsy_value_still_elicits(mock_connection):
+    """QGIS_MCP_AUTO_CONFIRM=0 keeps the normal confirmation path."""
+    from qgis_mcp.server import remove_layer
+
+    ctx = _make_ctx(elicitation="decline")
+    with patch.dict(os.environ, {"QGIS_MCP_AUTO_CONFIRM": "0"}):
+        output = await remove_layer(ctx, layer_id="test_layer")
+    assert output == {"ok": False, "message": "Cancelled by user"}
+    ctx.elicit.assert_called_once()
+    mock_connection.send_command.assert_not_called()
+
+
 # --- Env var configuration tests ---
 
 


### PR DESCRIPTION
## What

Adds an opt-in environment variable `QGIS_MCP_AUTO_CONFIRM` (`1`/`true`/`yes`/`on`) that skips the confirmation elicitation in `_confirm_destructive`. Default behavior is unchanged: unset (or any other value) keeps the elicitation exactly as today.

## Why

Clients that gate tool calls themselves see the elicitation as a redundant second confirmation. Claude Code, for example, already prompts for permission on every destructive-annotated tool call, then renders the elicitation as an awkward required-checkbox form on top — every `execute_code` costs two dialogs. The escape hatch follows the same rationale as the existing `McpError` fail-open path (#27's fix kept): the tools carry `destructiveHint` annotations, so a client's own gate can own the decision when the operator explicitly says so.

Deliberately explicit opt-in, read per call (a long-lived server honors changes), and logged when active — this never silently skips a confirmation, which is what #27 guarded against.

## Testing

- New test: `QGIS_MCP_AUTO_CONFIRM=1` proceeds without ever calling `ctx.elicit` (written first, red against the previous implementation).
- New negative control: `QGIS_MCP_AUTO_CONFIRM=0` keeps the normal elicitation path.
- Full unit suite: 180 passed on this branch.
- Live-tested against a running QGIS 3.44.7 through Claude Code: destructive tools run with one (client-side) confirmation instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YN5WTR6pUZRjWqEsqhukb